### PR TITLE
CODAP-1362: dirty current moment on first user action after Story Builder init

### DIFF
--- a/src/models/story_area.ts
+++ b/src/models/story_area.ts
@@ -290,15 +290,17 @@ export class StoryArea {
 					// to swallow the v2 echo of our own narrative-box create (v2 component
 					// notifications omit the id), but v3 excludes the requester from broadcasts,
 					// so the flag would otherwise silently eat the first legitimate user action.
-					// Clear the flag once we've observed any v3 component notification: at that
-					// point we know we're in v3, the v2 echo will never arrive, and leaving the
-					// flag set would let the catch-all below swallow a later id-less
-					// notification (e.g. a dataContext change).
 					if (!this.restoreInProgress) {
 						this.momentsManager.markCurrentMomentAsChanged(true);
 						this.changeCount++;
-						this.justMadeInitialMomentAndText = false;
 					}
+					// Clear the flag unconditionally: the flag exists only to swallow the
+					// id-less v2 echo, so any id-bearing notification proves the echo will
+					// never arrive (we're in v3, or the echo is already past). Clearing
+					// outside the restoreInProgress guard handles the narrow window where
+					// the new branch fires mid-restore — dirty is still suppressed there,
+					// but the flag must not be left set to bite a later id-less notification.
+					this.justMadeInitialMomentAndText = false;
 				} else if (!(this.justMadeInitialMomentAndText || this.restoreInProgress)) {
 					this.momentsManager.markCurrentMomentAsChanged(true);
 					this.changeCount++;

--- a/src/models/story_area.ts
+++ b/src/models/story_area.ts
@@ -282,6 +282,18 @@ export class StoryArea {
 				} else if (iCommand.values.operation === 'commitEdit' &&
 					iCommand.values.id === this.narrativeBoxID) {
 					this.momentsManager.setNewNarrative(iCommand.values.text);
+				} else if (iCommand.values.id !== undefined &&
+					iCommand.values.id !== this.narrativeBoxID) {
+					// CODAP v3 includes the component id in every notification. If it's not our
+					// narrative box, this is a real user action — mark the moment dirty without
+					// consulting justMadeInitialMomentAndText. That flag was designed to swallow
+					// the v2 echo of our own narrative-box create (v2 omits the id), but v3
+					// excludes the requester from broadcasts, so the flag would otherwise
+					// silently eat the first legitimate user action.
+					if (!this.restoreInProgress) {
+						this.momentsManager.markCurrentMomentAsChanged(true);
+						this.changeCount++;
+					}
 				} else if (!(this.justMadeInitialMomentAndText || this.restoreInProgress)) {
 					this.momentsManager.markCurrentMomentAsChanged(true);
 					this.changeCount++;

--- a/src/models/story_area.ts
+++ b/src/models/story_area.ts
@@ -284,15 +284,20 @@ export class StoryArea {
 					this.momentsManager.setNewNarrative(iCommand.values.text);
 				} else if (iCommand.values.id !== undefined &&
 					iCommand.values.id !== this.narrativeBoxID) {
-					// CODAP v3 includes the component id in every notification. If it's not our
-					// narrative box, this is a real user action — mark the moment dirty without
-					// consulting justMadeInitialMomentAndText. That flag was designed to swallow
-					// the v2 echo of our own narrative-box create (v2 omits the id), but v3
-					// excludes the requester from broadcasts, so the flag would otherwise
-					// silently eat the first legitimate user action.
+					// CODAP v3 component notifications always carry the component id. If it's
+					// not our narrative box, this is a real user action — mark the moment dirty
+					// without consulting justMadeInitialMomentAndText. That flag was designed
+					// to swallow the v2 echo of our own narrative-box create (v2 component
+					// notifications omit the id), but v3 excludes the requester from broadcasts,
+					// so the flag would otherwise silently eat the first legitimate user action.
+					// Clear the flag once we've observed any v3 component notification: at that
+					// point we know we're in v3, the v2 echo will never arrive, and leaving the
+					// flag set would let the catch-all below swallow a later id-less
+					// notification (e.g. a dataContext change).
 					if (!this.restoreInProgress) {
 						this.momentsManager.markCurrentMomentAsChanged(true);
 						this.changeCount++;
+						this.justMadeInitialMomentAndText = false;
 					}
 				} else if (!(this.justMadeInitialMomentAndText || this.restoreInProgress)) {
 					this.momentsManager.markCurrentMomentAsChanged(true);


### PR DESCRIPTION
## Summary
- Fixes the CODAP v3 bug where the first user action after adding Story Builder (graph, text, etc.) failed to mark the current moment dirty.
- Root cause: Story Builder's `justMadeInitialMomentAndText` flag was designed to swallow the v2 echo of its own narrative-box create. CODAP v3 (per concord-consortium/codap CODAP-1307) excludes the requesting plugin from notification broadcasts, so the echo never arrives. The flag stays set and silently consumes the user's first real action.
- Fix: in `handleNotification`, intercept notifications whose component id is known and isn't the narrative box's — mark the moment dirty without consulting the flag. v3 notifications always carry an id; v2 notifications omit it, so v2 falls through to the existing flag-based path unchanged.

## Test plan
- [ ] CODAP v3 + local Story Builder (`?pluginURL=http://localhost:3000/..`): new doc → add Story Builder → add a graph; moment turns yellow.
- [ ] Same setup: add Story Builder → add a text component; moment turns yellow.
- [ ] Add multiple components in succession — every one (not just the second onward) dirties the moment.
- [ ] CODAP v2 regression check: Story Builder's narrative-box create echo continues to be swallowed at init (no spurious dirty marker on initial Story Builder load).

Refs CODAP-1362.
