### PR TITLE
CODAP-1366: standalone build & deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+
+jobs:
+  build_test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Jest tests
+        run: CI=true npm test -- --watchAll=false
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+      - name: Build
+        run: npm run build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build/
+
+  deploy:
+    name: Deploy to S3
+    needs: build_test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: story-builder-deploy
+      cancel-in-progress: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: build
+
+      - name: Validate tag matches kSBVersion and package.json
+        run: |
+          TAG_VERSION="${TAG#v}"
+          SB_VERSION=$(sed -nE 's/.*kSBVersion = "([^"]+)".*/\1/p' src/models/story_builder.ts)
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
+          if [[ "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::Version mismatch — refusing to deploy."
+            exit 1
+          fi
+
+      - name: Sync to codap-resources (V3 read path)
+        run: |
+          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete
+
+      - name: Sync to models-resources root (canonical)
+        run: |
+          aws s3 sync build/ s3://models-resources/story-builder/ --delete \
+            --exclude "version/*"
+
+      - name: Archive to models-resources/version/<tag>/
+        run: |
+          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/
+
+      - name: Invalidate CloudFront (codap-resources)
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E1RS9TZVZBEEEC \
+            --paths "/plugins/story-builder/*"
+
+      - name: Invalidate CloudFront (models-resources)
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E1QHTGVGYD1DWZ \
+            --paths "/story-builder/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
     needs: build_test
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance
+      contents: read
     concurrency:
       group: story-builder-deploy
       cancel-in-progress: false
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
       TAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +62,11 @@ jobs:
             echo "::error::Version mismatch — refusing to deploy."
             exit 1
           fi
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/story-builder
+          aws-region: us-east-1
 
       - name: Sync to codap-resources (V3 read path)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches: [master]
-    tags: ['v*']
+    tags: ['v[0-9]*']
   pull_request:
 
 jobs:
@@ -31,15 +31,18 @@ jobs:
         with:
           name: build
           path: build/
+          if-no-files-found: error
 
   deploy:
     name: Deploy to S3
     needs: build_test
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write   # required for OIDC token issuance
       contents: read
+      actions: read     # required for download-artifact@v4 under restricted permissions
     concurrency:
       group: story-builder-deploy
       cancel-in-progress: false
@@ -55,11 +58,18 @@ jobs:
       - name: Validate tag matches kSBVersion and package.json
         run: |
           TAG_VERSION="${TAG#v}"
-          SB_VERSION=$(sed -nE 's/.*kSBVersion = "([^"]+)".*/\1/p' src/models/story_builder.ts)
+          SB_VERSION=$(sed -nE 's/.*kSBVersion = "([^"]+)".*/\1/p' src/models/story_builder.ts | head -1)
           PKG_VERSION=$(node -p "require('./package.json').version")
           echo "tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
-          if [[ "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
-            echo "::error::Version mismatch — refusing to deploy."
+          if [[ -z "$SB_VERSION" || -z "$PKG_VERSION" || "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::Version mismatch or empty value — refusing to deploy."
+            exit 1
+          fi
+
+      - name: Sanity-check build artifact
+        run: |
+          if [[ ! -s build/index.html ]]; then
+            echo "::error::build/index.html is missing or empty — refusing to sync (would wipe production)."
             exit 1
           fi
 
@@ -67,6 +77,12 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::612297603577:role/story-builder
           aws-region: us-east-1
+
+      # Write the immutable per-version archive FIRST so the canonical URLs
+      # are never updated without a corresponding archive existing.
+      - name: Archive to models-resources/version/<tag>/
+        run: |
+          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete
 
       - name: Sync to codap-resources (V3 read path)
         run: |
@@ -76,10 +92,6 @@ jobs:
         run: |
           aws s3 sync build/ s3://models-resources/story-builder/ --delete \
             --exclude "version/*"
-
-      - name: Archive to models-resources/version/<tag>/
-        run: |
-          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/
 
       - name: Invalidate CloudFront (codap-resources)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,28 +79,41 @@ jobs:
           aws-region: us-east-1
 
       # Write the immutable per-version archive FIRST so the canonical URLs
-      # are never updated without a corresponding archive existing.
+      # are never updated without a corresponding archive existing. The archive
+      # is by definition immutable, so long-cache applies to everything in it.
       - name: Archive to models-resources/version/<tag>/
         run: |
-          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete
+          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete \
+            --cache-control "public, max-age=31536000, immutable"
 
-      - name: Sync to codap-resources (V3 read path)
+      # Canonical syncs use a two-step pattern per target:
+      #   1. Upload hashed assets (build/static/) without --delete so old asset
+      #      versions linger to support any cached old HTML still referencing
+      #      them. Long cache + immutable is safe because filenames change with
+      #      content.
+      #   2. Upload HTML/manifests (everything outside build/static/) with
+      #      --delete and no-cache, so new HTML referencing new assets is
+      #      served immediately and old HTML doesn't linger.
+      # Orphan static assets accumulate slowly. Periodic pruning is future work.
+
+      - name: Sync hashed assets to codap-resources (V3 read path)
         run: |
-          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete
+          aws s3 sync build/static/ s3://codap-resources/plugins/story-builder/static/ \
+            --cache-control "public, max-age=31536000, immutable"
 
-      - name: Sync to models-resources root (canonical)
+      - name: Sync HTML/manifests to codap-resources (V3 read path)
+        run: |
+          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete \
+            --exclude "static/*" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      - name: Sync hashed assets to models-resources root (canonical)
+        run: |
+          aws s3 sync build/static/ s3://models-resources/story-builder/static/ \
+            --cache-control "public, max-age=31536000, immutable"
+
+      - name: Sync HTML/manifests to models-resources root (canonical)
         run: |
           aws s3 sync build/ s3://models-resources/story-builder/ --delete \
-            --exclude "version/*"
-
-      - name: Invalidate CloudFront (codap-resources)
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id E1RS9TZVZBEEEC \
-            --paths "/plugins/story-builder/*"
-
-      - name: Invalidate CloudFront (models-resources)
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id E1QHTGVGYD1DWZ \
-            --paths "/story-builder/*"
+            --exclude "static/*" --exclude "version/*" \
+            --cache-control "no-cache, no-store, must-revalidate"

--- a/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
+++ b/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
@@ -17,72 +17,113 @@
 | Action | File | Responsibility |
 |---|---|---|
 | Create | `.github/workflows/ci.yml` | Two-job CI/CD workflow (build_test + deploy) |
+| Modify (this branch, opportunistic) | `src/models/story_area.ts` | Drop unused `tSrcMoment` local in `toggleIsAutoSave` (CI=true surfaces this as a build-blocking ESLint warning) |
 | Modify (Stage 2 PR, separate from this branch) | `src/models/story_builder.ts` | Bump `kSBVersion` from `'0.86'` to `'0.87'` |
 | Modify (Stage 2 PR) | `package.json` | Bump `"version"` from `"0.1.0"` to `"0.87"` |
 
-The workflow file is the only code artifact on the `CODAP-1366-build-deploy` branch. The version bumps live on a separate Stage 2 PR (`CODAP-1366-release-0.87` branch, created in Task 5) so that Stage 1 commissioning (Task 4) can verify the validation step catches the natural mismatched state on master.
+The workflow file is the main code artifact on the `CODAP-1366-build-deploy` branch. The `story_area.ts` cleanup is opportunistic — `react-scripts build` under `CI=true` promotes ESLint warnings to errors, and the dead-code line `let tSrcMoment = this.momentsManager.srcMoment` in `toggleIsAutoSave` was a latent issue that blocked the first CI run on this branch. Removing it is unambiguously correct (the local was never read).
 
-No source-code changes outside these three files.
+The version bumps live on a separate Stage 2 PR (`CODAP-1366-release-0.87` branch, created in Task 5) so that Stage 1 commissioning (Task 4) can verify the validation step catches the natural mismatched state on master.
 
 ---
 
 ## Task 1: Verify AWS prerequisites
 
-**Purpose:** Confirm the workflow can authenticate and act before we hard-code IDs into the YAML.
+**Purpose:** Confirm the workflow can authenticate and act before we hard-code IDs into the YAML. Auth uses **GitHub OIDC** (no long-lived secrets, per org convention) — see [concord-consortium/starter-projects/doc/deploy-setup.md](https://github.com/concord-consortium/starter-projects/blob/master/doc/deploy-setup.md).
 
 **Files:** none (this task only gathers values; nothing is committed).
 
-- [ ] **Step 1: Confirm `concord-consortium/story-builder` has org-level AWS secrets inherited**
+- [ ] **Step 1: Confirm bucket public-read access via bucket policy**
 
-Visit `https://github.com/concord-consortium/story-builder/settings/secrets/actions` in the browser. Expected: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` appear in the "Organization secrets" section (inherited, not repository-overridden). If they don't, ask repo admin / org admin to grant the story-builder repo access to the existing org secrets.
-
-- [ ] **Step 2: Confirm IAM permissions for those creds**
-
-Run from a shell where the same AWS creds are configured (or have an AWS admin run):
+Both `codap-resources` and `models-resources` grant public read via a **bucket policy** (`s3:GetObject` for `Principal: *`), not per-object ACLs. The workflow therefore does **not** pass `--acl public-read` on its sync commands. Verify:
 
 ```bash
-aws sts get-caller-identity   # confirm which IAM principal you're testing
-aws iam simulate-principal-policy \
-  --policy-source-arn <PRINCIPAL_ARN> \
-  --action-names s3:PutObject s3:DeleteObject s3:ListBucket \
-  --resource-arns \
-      arn:aws:s3:::codap-resources/plugins/story-builder/* \
-      arn:aws:s3:::models-resources/story-builder/*
-aws iam simulate-principal-policy \
-  --policy-source-arn <PRINCIPAL_ARN> \
-  --action-names cloudfront:CreateInvalidation \
-  --resource-arns \
-      arn:aws:cloudfront::*:distribution/E1RS9TZVZBEEEC
+aws s3api get-bucket-policy --bucket codap-resources --query Policy --output text | jq .
+aws s3api get-bucket-policy --bucket models-resources --query Policy --output text | jq .
 ```
 
-Expected: every action returns `EvalDecision: allowed`. If any return `implicitDeny` or `explicitDeny`, request an IAM policy update before continuing.
+Expected: both responses include a statement allowing `s3:GetObject` from `Principal: "*"` on `arn:aws:s3:::<bucket>/*`. If a policy is missing or differs, surface that with the AWS admin before continuing — switching to ACL-based access requires changes to both the workflow YAML and the bucket ownership controls.
 
-- [ ] **Step 3: Confirm bucket ACL configuration permits `--acl public-read`**
-
-```bash
-aws s3api get-bucket-ownership-controls --bucket codap-resources \
-  --query 'OwnershipControls.Rules[0].ObjectOwnership' --output text
-aws s3api get-bucket-ownership-controls --bucket models-resources \
-  --query 'OwnershipControls.Rules[0].ObjectOwnership' --output text
-```
-
-Expected: either `BucketOwnerPreferred` or `ObjectWriter`. If either returns `BucketOwnerEnforced`, ACLs are disabled and the spec's contingency applies — revisit the design before writing the workflow (either re-enable ACLs on that bucket or drop `--acl public-read` from the workflow and rely on bucket-policy-based public access).
-
-- [ ] **Step 4: Look up the CloudFront distribution ID for `models-resources`**
+- [ ] **Step 2: Look up the CloudFront distribution ID for `models-resources`**
 
 ```bash
 aws cloudfront list-distributions \
   --query 'DistributionList.Items[?contains(Aliases.Items[0], `models-resources`) || contains(Origins.Items[0].DomainName, `models-resources.s3`)].{Id:Id,Aliases:Aliases.Items,Origin:Origins.Items[0].DomainName}' \
-  --output table
+  --output text
 ```
 
-Expected: a single row with the distribution ID. Record the ID — you'll paste it into the workflow file in Task 2 Step 3. If you find more than one matching distribution, pick the one whose alias is `models-resources.concord.org` (or ask whoever maintains the org's AWS infra).
+Expected: at least one matching distribution. Pick the one whose alias is `models-resources.concord.org` (resolved during initial AWS exploration: `E1QHTGVGYD1DWZ`). The codap-resources distribution is `E1RS9TZVZBEEEC` (already known and hard-coded in the workflow).
 
-- [ ] **Step 5: Record findings**
+- [ ] **Step 3: Set up the OIDC IAM role**
 
-Write the discovered `<MODELS_RESOURCES_DIST_ID>` value and the IAM principal name in a scratch note (e.g., on the CODAP-1366 Jira issue). You'll reference the distribution ID in Task 2. The IAM principal is for documentation / future debugging only.
+Coordinate with an AWS admin (someone with IAM admin in account `612297603577`). From a checkout of `concord-consortium/starter-projects`:
 
-If any of Steps 1–3 fails, **stop** and resolve the underlying issue before proceeding to Task 2. Don't write the workflow against an environment that can't run it.
+```bash
+./scripts/create-deploy-role.sh story-builder
+```
+
+That script creates IAM role `story-builder`, tags it `RepoName=story-builder`, sets a trust policy scoped to `repo:concord-consortium/story-builder:*` (only this repo's workflows can assume it), and attaches the shared `S3-deploy-by-role-tag` managed policy. The shared policy grants S3 access to `models-resources/${aws:PrincipalTag/RepoName}/*` — i.e., `models-resources/story-builder/*` for our role.
+
+- [ ] **Step 4: Attach the supplemental inline policy**
+
+The shared policy doesn't cover `codap-resources` writes or `cloudfront:CreateInvalidation`. Attach this supplemental inline policy to the `story-builder` role (save as `story-builder-supplemental-policy.json`):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "WriteCodapResourcesStoryBuilder",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::codap-resources/plugins/story-builder/*"
+    },
+    {
+      "Sid": "ListCodapResourcesForSync",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::codap-resources",
+      "Condition": {
+        "StringLike": { "s3:prefix": "plugins/story-builder/*" }
+      }
+    },
+    {
+      "Sid": "InvalidateCloudFront",
+      "Effect": "Allow",
+      "Action": "cloudfront:CreateInvalidation",
+      "Resource": [
+        "arn:aws:cloudfront::612297603577:distribution/E1RS9TZVZBEEEC",
+        "arn:aws:cloudfront::612297603577:distribution/E1QHTGVGYD1DWZ"
+      ]
+    }
+  ]
+}
+```
+
+Apply:
+
+```bash
+aws iam put-role-policy \
+  --role-name story-builder \
+  --policy-name story-builder-supplemental \
+  --policy-document file://story-builder-supplemental-policy.json
+```
+
+- [ ] **Step 5: Verify the role exists and has both policies**
+
+```bash
+aws iam get-role --role-name story-builder
+aws iam list-attached-role-policies --role-name story-builder
+aws iam list-role-policies --role-name story-builder
+```
+
+Expected: role exists with `RepoName=story-builder` tag; `S3-deploy-by-role-tag` appears in attached policies; `story-builder-supplemental` appears in inline policies.
+
+- [ ] **Step 6: Record findings**
+
+Note the resolved values on the CODAP-1366 Jira issue: role ARN `arn:aws:iam::612297603577:role/story-builder`, models-resources distribution `E1QHTGVGYD1DWZ`, codap-resources distribution `E1RS9TZVZBEEEC`.
+
+If any of Steps 3–5 fails, **stop** and resolve the underlying issue (IAM permissions, role conflict, policy syntax) before proceeding. The workflow can still be merged before this is done — `build_test` runs without any AWS involvement — but the `deploy` job will fail on its first tag push until the role is in place.
 
 ---
 
@@ -125,7 +166,7 @@ Expected: empty directory (the repo has no existing workflows — confirmed duri
 
 - [ ] **Step 3: Write `.github/workflows/ci.yml`**
 
-Substitute the `<MODELS_RESOURCES_DIST_ID>` placeholder near the bottom with the real distribution ID you recorded in Task 1 Step 4. Everything else is literal.
+The deploy job uses **GitHub OIDC** to assume the `story-builder` IAM role created in Task 1 — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets are needed, and `--acl public-read` is omitted on syncs because bucket policies handle public access.
 
 ```yaml
 name: Continuous Integration
@@ -167,13 +208,13 @@ jobs:
     needs: build_test
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance
+      contents: read
     concurrency:
       group: story-builder-deploy
       cancel-in-progress: false
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
       TAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
@@ -193,21 +234,23 @@ jobs:
             exit 1
           fi
 
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/story-builder
+          aws-region: us-east-1
+
       - name: Sync to codap-resources (V3 read path)
         run: |
-          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ \
-            --acl public-read --delete
+          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete
 
       - name: Sync to models-resources root (canonical)
         run: |
-          aws s3 sync build/ s3://models-resources/story-builder/ \
-            --acl public-read --delete \
+          aws s3 sync build/ s3://models-resources/story-builder/ --delete \
             --exclude "version/*"
 
       - name: Archive to models-resources/version/<tag>/
         run: |
-          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ \
-            --acl public-read
+          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/
 
       - name: Invalidate CloudFront (codap-resources)
         run: |
@@ -218,31 +261,21 @@ jobs:
       - name: Invalidate CloudFront (models-resources)
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id <MODELS_RESOURCES_DIST_ID> \
+            --distribution-id E1QHTGVGYD1DWZ \
             --paths "/story-builder/*"
 ```
 
 - [ ] **Step 4: Sanity-check the YAML parses**
 
-Run:
+Run (Python 3 with pyyaml, or Ruby with YAML):
 
 ```bash
-python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"
+ruby -ryaml -e 'YAML.safe_load(File.read(".github/workflows/ci.yml")); puts "YAML OK"'
 ```
 
-Expected: `YAML OK`. If you get a YAMLError, re-check indentation (workflows are sensitive to tabs vs. spaces — the file above uses 2-space indentation throughout).
+Expected: `YAML OK`. If you get a parse error, re-check indentation (workflows are sensitive to tabs vs. spaces — the file above uses 2-space indentation throughout).
 
-- [ ] **Step 5: Verify the placeholder was replaced**
-
-Run:
-
-```bash
-grep -n "MODELS_RESOURCES_DIST_ID" .github/workflows/ci.yml
-```
-
-Expected: **no output**. If grep finds the placeholder string, you forgot to substitute it in Step 3.
-
-- [ ] **Step 6: Verify locally that the validation step's bash logic is correct against the *current* mismatched state**
+- [ ] **Step 5: Verify locally that the validation step's bash logic is correct against the *current* mismatched state**
 
 Run the same logic the workflow will run, in your shell, against the working tree (which still has the mismatched versions):
 
@@ -261,7 +294,7 @@ tag=0.86 kSBVersion=0.86 package.json=0.1.0
 
 This confirms the sed and node lookups work against the real files. The mismatch (`0.86 != 0.1.0`) is the failure mode Stage 1 will exercise.
 
-- [ ] **Step 7: Commit the workflow**
+- [ ] **Step 6: Commit the workflow**
 
 ```bash
 git add .github/workflows/ci.yml
@@ -618,7 +651,7 @@ Expected: all three list builds with recent LastModified timestamps (within the 
 
 ```bash
 aws cloudfront list-invalidations --distribution-id E1RS9TZVZBEEEC --max-items 3
-aws cloudfront list-invalidations --distribution-id <MODELS_RESOURCES_DIST_ID> --max-items 3
+aws cloudfront list-invalidations --distribution-id E1QHTGVGYD1DWZ --max-items 3
 ```
 
 Expected: the most recent invalidation on each distribution has `Status: Completed` (or `InProgress` if you check within a minute). Note the IDs — they'll typically match what step 4 printed.

--- a/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
+++ b/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
@@ -174,7 +174,7 @@ name: Continuous Integration
 on:
   push:
     branches: [master]
-    tags: ['v*']
+    tags: ['v[0-9]*']
   pull_request:
 
 jobs:
@@ -202,15 +202,18 @@ jobs:
         with:
           name: build
           path: build/
+          if-no-files-found: error
 
   deploy:
     name: Deploy to S3
     needs: build_test
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write   # required for OIDC token issuance
       contents: read
+      actions: read     # required for download-artifact@v4 under restricted permissions
     concurrency:
       group: story-builder-deploy
       cancel-in-progress: false
@@ -226,11 +229,18 @@ jobs:
       - name: Validate tag matches kSBVersion and package.json
         run: |
           TAG_VERSION="${TAG#v}"
-          SB_VERSION=$(sed -nE 's/.*kSBVersion = "([^"]+)".*/\1/p' src/models/story_builder.ts)
+          SB_VERSION=$(sed -nE 's/.*kSBVersion = "([^"]+)".*/\1/p' src/models/story_builder.ts | head -1)
           PKG_VERSION=$(node -p "require('./package.json').version")
           echo "tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
-          if [[ "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
-            echo "::error::Version mismatch — refusing to deploy."
+          if [[ -z "$SB_VERSION" || -z "$PKG_VERSION" || "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::Version mismatch or empty value — refusing to deploy."
+            exit 1
+          fi
+
+      - name: Sanity-check build artifact
+        run: |
+          if [[ ! -s build/index.html ]]; then
+            echo "::error::build/index.html is missing or empty — refusing to sync (would wipe production)."
             exit 1
           fi
 
@@ -238,6 +248,12 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::612297603577:role/story-builder
           aws-region: us-east-1
+
+      # Write the immutable per-version archive FIRST so the canonical URLs
+      # are never updated without a corresponding archive existing.
+      - name: Archive to models-resources/version/<tag>/
+        run: |
+          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete
 
       - name: Sync to codap-resources (V3 read path)
         run: |
@@ -247,10 +263,6 @@ jobs:
         run: |
           aws s3 sync build/ s3://models-resources/story-builder/ --delete \
             --exclude "version/*"
-
-      - name: Archive to models-resources/version/<tag>/
-        run: |
-          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/
 
       - name: Invalidate CloudFront (codap-resources)
         run: |

--- a/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
+++ b/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a GitHub Actions workflow to `concord-consortium/story-builder` that builds + tests on every push/PR and deploys to two S3 buckets + invalidates CloudFront on `v*` tag push. First live ship is the CODAP-1362 fix.
+**Goal:** Add a GitHub Actions workflow to `concord-consortium/story-builder` that builds + tests on every push/PR and deploys to two S3 buckets + invalidates CloudFront on `v[0-9]*` tag push. First live ship is the CODAP-1362 fix.
 
 **Architecture:** Single workflow file (`.github/workflows/ci.yml`) with two jobs. `build_test` (always) runs `npm ci` + Jest + `npm run build` and uploads `build/` as an artifact. `deploy` (tag-only, `needs: build_test`) downloads the artifact, validates that tag + `kSBVersion` + `package.json` version all agree, then `aws s3 sync`s to `codap-resources/plugins/story-builder/`, `models-resources/story-builder/`, and `models-resources/story-builder/version/<tag>/`, and finally creates CloudFront invalidations on both distributions. Concurrency group on `deploy` serializes tag races.
 
@@ -314,7 +314,7 @@ git commit -m "$(cat <<'EOF'
 CODAP-1366: add ci.yml for build + S3 deploy on tag
 
 Build & test on every push to master and every PR. Deploy job
-(tag-only, v*) downloads the build_test artifact, validates that
+(tag-only, v[0-9]*) downloads the build_test artifact, validates that
 kSBVersion + package.json version + tag all agree, then syncs to
 codap-resources/plugins/story-builder/ and to models-resources/
 story-builder/ (root + version/<tag>/ archive), and creates
@@ -358,7 +358,7 @@ gh pr create \
   --title "CODAP-1366: standalone build & deploy workflow" \
   --body "$(cat <<'EOF'
 ## Summary
-- Adds `.github/workflows/ci.yml`: build + Jest test on every push/PR; deploys to S3 + CloudFront on `v*` tag push.
+- Adds `.github/workflows/ci.yml`: build + Jest test on every push/PR; deploys to S3 + CloudFront on `v[0-9]*` tag push.
 - Adds the design spec at `docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md` covering rationale, decisions, and commissioning plan.
 - Dual-bucket publish during the V2→V3 transition: `codap-resources/plugins/story-builder/` (current V3 read path) and `models-resources/story-builder/` (org standard + per-tag archive).
 
@@ -641,11 +641,12 @@ gh run watch
 Expected sequence (~3–5 minutes total):
 1. `Build & Test` job: succeeds (artifact uploaded).
 2. `Deploy to S3` job validation step: prints `tag=0.87 kSBVersion=0.87 package.json=0.87`, no error.
-3. `Sync to codap-resources` step: completes, lists uploaded files.
-4. `Sync to models-resources root` step: completes.
-5. `Archive to models-resources/version/<tag>/` step: completes.
-6. `Invalidate CloudFront (codap-resources)` step: completes; prints an invalidation ID.
-7. `Invalidate CloudFront (models-resources)` step: completes; prints an invalidation ID.
+3. `Sanity-check build artifact` step: passes (build/index.html present and non-empty).
+4. `Archive to models-resources/version/<tag>/` step: completes (archive lands first so canonical URLs are never updated without a matching archive).
+5. `Sync to codap-resources` step: completes, lists uploaded files.
+6. `Sync to models-resources root` step: completes.
+7. `Invalidate CloudFront (codap-resources)` step: completes; prints an invalidation ID.
+8. `Invalidate CloudFront (models-resources)` step: completes; prints an invalidation ID.
 
 If any step fails, the spec's Error Handling section applies — re-run the failed job from the Actions UI (`gh run rerun <run-id> --failed`).
 

--- a/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
+++ b/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a GitHub Actions workflow to `concord-consortium/story-builder` that builds + tests on every push/PR and deploys to two S3 buckets + invalidates CloudFront on `v[0-9]*` tag push. First live ship is the CODAP-1362 fix.
+**Goal:** Add a GitHub Actions workflow to `concord-consortium/story-builder` that builds + tests on every push/PR and deploys to two S3 buckets on `v[0-9]*` tag push, with per-file `Cache-Control` headers (no-cache for HTML, long-cache + immutable for hashed assets) instead of CloudFront invalidation. First live ship is the CODAP-1362 fix.
 
-**Architecture:** Single workflow file (`.github/workflows/ci.yml`) with two jobs. `build_test` (always) runs `npm ci` + Jest + `npm run build` and uploads `build/` as an artifact. `deploy` (tag-only, `needs: build_test`) downloads the artifact, validates that tag + `kSBVersion` + `package.json` version all agree, then `aws s3 sync`s to `codap-resources/plugins/story-builder/`, `models-resources/story-builder/`, and `models-resources/story-builder/version/<tag>/`, and finally creates CloudFront invalidations on both distributions. Concurrency group on `deploy` serializes tag races.
+**Architecture:** Single workflow file (`.github/workflows/ci.yml`) with two jobs. `build_test` (always) runs `npm ci` + Jest + `npm run build` and uploads `build/` as an artifact. `deploy` (tag-only, `needs: build_test`) downloads the artifact, validates that tag + `kSBVersion` + `package.json` version all agree, then `aws s3 sync`s to `models-resources/story-builder/version/<tag>/` (archive), `codap-resources/plugins/story-builder/`, and `models-resources/story-builder/` — each canonical target in two passes (hashed assets long-cached + immutable, then HTML/manifests no-cached). Concurrency group on `deploy` serializes tag races.
 
-**Tech Stack:** GitHub Actions, AWS CLI v2 (`aws s3 sync`, `aws cloudfront create-invalidation`), Node 18 (with `--openssl-legacy-provider` for react-scripts 4 / webpack 4 compatibility), Jest via `react-scripts test`.
+**Tech Stack:** GitHub Actions, AWS CLI v2 (`aws s3 sync`), Node 18 (with `--openssl-legacy-provider` for react-scripts 4 / webpack 4 compatibility), Jest via `react-scripts test`.
 
 **Reference:** [Design spec](../specs/2026-05-26-story-builder-build-and-deploy-design.md). **Jira:** [CODAP-1366](https://concord-consortium.atlassian.net/browse/CODAP-1366). Working branch: `CODAP-1366-build-deploy`.
 
@@ -66,7 +66,7 @@ That script creates IAM role `story-builder`, tags it `RepoName=story-builder`, 
 
 - [ ] **Step 4: Attach the supplemental inline policy**
 
-The shared policy doesn't cover `codap-resources` writes or `cloudfront:CreateInvalidation`. Attach this supplemental inline policy to the `story-builder` role (save as `story-builder-supplemental-policy.json`):
+The shared policy doesn't cover `codap-resources` writes. Attach this supplemental inline policy to the `story-builder` role (save as `story-builder-supplemental-policy.json`):
 
 ```json
 {
@@ -86,19 +86,12 @@ The shared policy doesn't cover `codap-resources` writes or `cloudfront:CreateIn
       "Condition": {
         "StringLike": { "s3:prefix": "plugins/story-builder/*" }
       }
-    },
-    {
-      "Sid": "InvalidateCloudFront",
-      "Effect": "Allow",
-      "Action": "cloudfront:CreateInvalidation",
-      "Resource": [
-        "arn:aws:cloudfront::612297603577:distribution/E1RS9TZVZBEEEC",
-        "arn:aws:cloudfront::612297603577:distribution/E1QHTGVGYD1DWZ"
-      ]
     }
   ]
 }
 ```
+
+(No `cloudfront:CreateInvalidation` — the workflow uses per-file `Cache-Control` headers so invalidation is unnecessary. See spec §Cache strategy.)
 
 Apply:
 
@@ -253,28 +246,32 @@ jobs:
       # are never updated without a corresponding archive existing.
       - name: Archive to models-resources/version/<tag>/
         run: |
-          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete
+          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete \
+            --cache-control "public, max-age=31536000, immutable"
 
-      - name: Sync to codap-resources (V3 read path)
+      # Canonical syncs: hashed assets first (additive, long-cache), then
+      # HTML/manifests (--delete, no-cache). See spec §Cache strategy.
+      - name: Sync hashed assets to codap-resources (V3 read path)
         run: |
-          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete
+          aws s3 sync build/static/ s3://codap-resources/plugins/story-builder/static/ \
+            --cache-control "public, max-age=31536000, immutable"
 
-      - name: Sync to models-resources root (canonical)
+      - name: Sync HTML/manifests to codap-resources (V3 read path)
+        run: |
+          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete \
+            --exclude "static/*" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      - name: Sync hashed assets to models-resources root (canonical)
+        run: |
+          aws s3 sync build/static/ s3://models-resources/story-builder/static/ \
+            --cache-control "public, max-age=31536000, immutable"
+
+      - name: Sync HTML/manifests to models-resources root (canonical)
         run: |
           aws s3 sync build/ s3://models-resources/story-builder/ --delete \
-            --exclude "version/*"
-
-      - name: Invalidate CloudFront (codap-resources)
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id E1RS9TZVZBEEEC \
-            --paths "/plugins/story-builder/*"
-
-      - name: Invalidate CloudFront (models-resources)
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id E1QHTGVGYD1DWZ \
-            --paths "/story-builder/*"
+            --exclude "static/*" --exclude "version/*" \
+            --cache-control "no-cache, no-store, must-revalidate"
 ```
 
 - [ ] **Step 4: Sanity-check the YAML parses**
@@ -318,7 +315,7 @@ Build & test on every push to master and every PR. Deploy job
 kSBVersion + package.json version + tag all agree, then syncs to
 codap-resources/plugins/story-builder/ and to models-resources/
 story-builder/ (root + version/<tag>/ archive), and creates
-CloudFront invalidations on both distributions.
+per-file Cache-Control headers (no-cache for HTML, long-cache + immutable for hashed assets).
 
 See docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
 for the full design rationale.
@@ -358,7 +355,7 @@ gh pr create \
   --title "CODAP-1366: standalone build & deploy workflow" \
   --body "$(cat <<'EOF'
 ## Summary
-- Adds `.github/workflows/ci.yml`: build + Jest test on every push/PR; deploys to S3 + CloudFront on `v[0-9]*` tag push.
+- Adds `.github/workflows/ci.yml`: build + Jest test on every push/PR; deploys to S3 (with per-file Cache-Control headers — no CloudFront invalidation needed) on `v[0-9]*` tag push.
 - Adds the design spec at `docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md` covering rationale, decisions, and commissioning plan.
 - Dual-bucket publish during the V2→V3 transition: `codap-resources/plugins/story-builder/` (current V3 read path) and `models-resources/story-builder/` (org standard + per-tag archive).
 
@@ -449,7 +446,7 @@ gh run watch  # picks up the most recent run; or pass the run ID
 Expected:
 - `Build & Test` job succeeds (the source compiles and the test passes; nothing is wrong with the code at this commit).
 - `Deploy to S3` job runs the validation step, prints `tag=0.86 kSBVersion=0.86 package.json=0.1.0`, then the `::error::Version mismatch — refusing to deploy.` annotation, and exits non-zero.
-- **No subsequent S3 sync or CloudFront step runs** (because validation failed).
+- **No subsequent S3 sync step runs** (because validation failed).
 
 - [ ] **Step 5: Verify nothing was written to S3**
 
@@ -573,7 +570,7 @@ gh pr create \
 
 ## Test plan
 - [ ] CI build + test passes on this PR.
-- [ ] After merge, tag `v0.87` at the new HEAD. Confirm the deploy job validates successfully, syncs to both buckets + the `version/v0.87/` archive, and creates both CloudFront invalidations.
+- [ ] After merge, tag `v0.87` at the new HEAD. Confirm the deploy job validates successfully and syncs to both buckets + the `version/v0.87/` archive with the correct Cache-Control headers.
 - [ ] Confirm CODAP V3 picks up the new build (CODAP-1362 fix verifiable: adding Story Builder to a v3 doc, then a graph, dirties the moment).
 
 Refs CODAP-1366.
@@ -597,7 +594,7 @@ After merging, continue to Task 6 to push the tag.
 
 ## Task 6: Stage 2 commissioning — live deploy of `v0.87`
 
-**Purpose:** Push the `v0.87` tag, watch the full deploy run, verify the artifacts land in S3 and CloudFront is invalidated.
+**Purpose:** Push the `v0.87` tag, watch the full deploy run, verify the artifacts land in S3 with the right `Cache-Control` headers and that CODAP V3 sees the fix.
 
 **Files:** none.
 
@@ -643,10 +640,10 @@ Expected sequence (~3–5 minutes total):
 2. `Deploy to S3` job validation step: prints `tag=0.87 kSBVersion=0.87 package.json=0.87`, no error.
 3. `Sanity-check build artifact` step: passes (build/index.html present and non-empty).
 4. `Archive to models-resources/version/<tag>/` step: completes (archive lands first so canonical URLs are never updated without a matching archive).
-5. `Sync to codap-resources` step: completes, lists uploaded files.
-6. `Sync to models-resources root` step: completes.
-7. `Invalidate CloudFront (codap-resources)` step: completes; prints an invalidation ID.
-8. `Invalidate CloudFront (models-resources)` step: completes; prints an invalidation ID.
+5. `Sync hashed assets to codap-resources` step: completes.
+6. `Sync HTML/manifests to codap-resources` step: completes.
+7. `Sync hashed assets to models-resources root` step: completes.
+8. `Sync HTML/manifests to models-resources root` step: completes.
 
 If any step fails, the spec's Error Handling section applies — re-run the failed job from the Actions UI (`gh run rerun <run-id> --failed`).
 
@@ -660,14 +657,22 @@ aws s3 ls s3://models-resources/story-builder/version/v0.87/ --recursive | head 
 
 Expected: all three list builds with recent LastModified timestamps (within the last few minutes). The contents should match `build/` from a local `npm run build` — at a minimum, `index.html`, `asset-manifest.json`, `static/js/main.*.js`, `static/css/main.*.css`.
 
-- [ ] **Step 6: Verify both CloudFront invalidations completed**
+- [ ] **Step 6: Verify `Cache-Control` headers are correct on a sample of objects**
 
 ```bash
-aws cloudfront list-invalidations --distribution-id E1RS9TZVZBEEEC --max-items 3
-aws cloudfront list-invalidations --distribution-id E1QHTGVGYD1DWZ --max-items 3
+# HTML — should be no-cache
+aws s3api head-object --bucket codap-resources --key plugins/story-builder/index.html \
+  --query CacheControl --output text
+aws s3api head-object --bucket models-resources --key story-builder/index.html \
+  --query CacheControl --output text
+
+# Hashed asset — should be long-cache + immutable
+aws s3api head-object --bucket codap-resources \
+  --key "$(aws s3 ls s3://codap-resources/plugins/story-builder/static/js/ | awk '/main\..*\.js/ {print "plugins/story-builder/static/js/"$NF; exit}')" \
+  --query CacheControl --output text
 ```
 
-Expected: the most recent invalidation on each distribution has `Status: Completed` (or `InProgress` if you check within a minute). Note the IDs — they'll typically match what step 4 printed.
+Expected: HTML returns `no-cache, no-store, must-revalidate`. Hashed-asset returns `public, max-age=31536000, immutable`. Anything else means the sync's `--cache-control` flag didn't take.
 
 - [ ] **Step 7: Smoke-test in CODAP V3 (functional verification)**
 
@@ -676,11 +681,11 @@ Open a CODAP V3 instance (typically `https://codap3.concord.org/` or your local 
 1. Story Builder loads (no 404, no script errors in the console — the plugin URL resolves to the freshly synced `codap-resources/plugins/story-builder/` content).
 2. The CODAP-1362 fix is present: with Story Builder added, add a graph; the first moment turns yellow (dirty). This is the user-visible bug fix this whole release is shipping.
 
-If Story Builder loads but the CODAP-1362 fix isn't present, the most likely cause is CloudFront serving stale cached HTML. Wait 1–2 minutes for invalidation to propagate, then hard-refresh. If it persists, manually invalidate again via `aws cloudfront create-invalidation --distribution-id E1RS9TZVZBEEEC --paths "/plugins/story-builder/*"`.
+If Story Builder loads but the CODAP-1362 fix isn't present, the most likely cause is a stale browser cache from a previous session (the workflow's `no-cache` header is for the new HTML; the user's browser may still have the previous response cached briefly). Hard-refresh (Cmd-Shift-R / Ctrl-Shift-R). If it still persists, verify the new HTML actually shipped to S3 (`aws s3api head-object`) and check its `LastModified` matches the deploy time.
 
 - [ ] **Step 8: Record Stage 2 result**
 
-Note in the CODAP-1366 Jira issue: "Stage 2 commissioning complete. `v0.87` tag pushed; full deploy succeeded; CODAP-1362 fix verified live in V3." Link to the successful workflow run URL and the relevant CloudFront invalidation IDs.
+Note in the CODAP-1366 Jira issue: "Stage 2 commissioning complete. `v0.87` tag pushed; full deploy succeeded; CODAP-1362 fix verified live in V3." Link to the successful workflow run URL.
 
 Also update CODAP-1362's Jira issue to "Deployed" (or your team's equivalent status) and note that the fix is live as of `v0.87`.
 

--- a/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
+++ b/docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md
@@ -1,0 +1,685 @@
+# Story Builder Build & Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub Actions workflow to `concord-consortium/story-builder` that builds + tests on every push/PR and deploys to two S3 buckets + invalidates CloudFront on `v*` tag push. First live ship is the CODAP-1362 fix.
+
+**Architecture:** Single workflow file (`.github/workflows/ci.yml`) with two jobs. `build_test` (always) runs `npm ci` + Jest + `npm run build` and uploads `build/` as an artifact. `deploy` (tag-only, `needs: build_test`) downloads the artifact, validates that tag + `kSBVersion` + `package.json` version all agree, then `aws s3 sync`s to `codap-resources/plugins/story-builder/`, `models-resources/story-builder/`, and `models-resources/story-builder/version/<tag>/`, and finally creates CloudFront invalidations on both distributions. Concurrency group on `deploy` serializes tag races.
+
+**Tech Stack:** GitHub Actions, AWS CLI v2 (`aws s3 sync`, `aws cloudfront create-invalidation`), Node 18 (with `--openssl-legacy-provider` for react-scripts 4 / webpack 4 compatibility), Jest via `react-scripts test`.
+
+**Reference:** [Design spec](../specs/2026-05-26-story-builder-build-and-deploy-design.md). **Jira:** [CODAP-1366](https://concord-consortium.atlassian.net/browse/CODAP-1366). Working branch: `CODAP-1366-build-deploy`.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|---|---|---|
+| Create | `.github/workflows/ci.yml` | Two-job CI/CD workflow (build_test + deploy) |
+| Modify (Stage 2 PR, separate from this branch) | `src/models/story_builder.ts` | Bump `kSBVersion` from `'0.86'` to `'0.87'` |
+| Modify (Stage 2 PR) | `package.json` | Bump `"version"` from `"0.1.0"` to `"0.87"` |
+
+The workflow file is the only code artifact on the `CODAP-1366-build-deploy` branch. The version bumps live on a separate Stage 2 PR (`CODAP-1366-release-0.87` branch, created in Task 5) so that Stage 1 commissioning (Task 4) can verify the validation step catches the natural mismatched state on master.
+
+No source-code changes outside these three files.
+
+---
+
+## Task 1: Verify AWS prerequisites
+
+**Purpose:** Confirm the workflow can authenticate and act before we hard-code IDs into the YAML.
+
+**Files:** none (this task only gathers values; nothing is committed).
+
+- [ ] **Step 1: Confirm `concord-consortium/story-builder` has org-level AWS secrets inherited**
+
+Visit `https://github.com/concord-consortium/story-builder/settings/secrets/actions` in the browser. Expected: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` appear in the "Organization secrets" section (inherited, not repository-overridden). If they don't, ask repo admin / org admin to grant the story-builder repo access to the existing org secrets.
+
+- [ ] **Step 2: Confirm IAM permissions for those creds**
+
+Run from a shell where the same AWS creds are configured (or have an AWS admin run):
+
+```bash
+aws sts get-caller-identity   # confirm which IAM principal you're testing
+aws iam simulate-principal-policy \
+  --policy-source-arn <PRINCIPAL_ARN> \
+  --action-names s3:PutObject s3:DeleteObject s3:ListBucket \
+  --resource-arns \
+      arn:aws:s3:::codap-resources/plugins/story-builder/* \
+      arn:aws:s3:::models-resources/story-builder/*
+aws iam simulate-principal-policy \
+  --policy-source-arn <PRINCIPAL_ARN> \
+  --action-names cloudfront:CreateInvalidation \
+  --resource-arns \
+      arn:aws:cloudfront::*:distribution/E1RS9TZVZBEEEC
+```
+
+Expected: every action returns `EvalDecision: allowed`. If any return `implicitDeny` or `explicitDeny`, request an IAM policy update before continuing.
+
+- [ ] **Step 3: Confirm bucket ACL configuration permits `--acl public-read`**
+
+```bash
+aws s3api get-bucket-ownership-controls --bucket codap-resources \
+  --query 'OwnershipControls.Rules[0].ObjectOwnership' --output text
+aws s3api get-bucket-ownership-controls --bucket models-resources \
+  --query 'OwnershipControls.Rules[0].ObjectOwnership' --output text
+```
+
+Expected: either `BucketOwnerPreferred` or `ObjectWriter`. If either returns `BucketOwnerEnforced`, ACLs are disabled and the spec's contingency applies — revisit the design before writing the workflow (either re-enable ACLs on that bucket or drop `--acl public-read` from the workflow and rely on bucket-policy-based public access).
+
+- [ ] **Step 4: Look up the CloudFront distribution ID for `models-resources`**
+
+```bash
+aws cloudfront list-distributions \
+  --query 'DistributionList.Items[?contains(Aliases.Items[0], `models-resources`) || contains(Origins.Items[0].DomainName, `models-resources.s3`)].{Id:Id,Aliases:Aliases.Items,Origin:Origins.Items[0].DomainName}' \
+  --output table
+```
+
+Expected: a single row with the distribution ID. Record the ID — you'll paste it into the workflow file in Task 2 Step 3. If you find more than one matching distribution, pick the one whose alias is `models-resources.concord.org` (or ask whoever maintains the org's AWS infra).
+
+- [ ] **Step 5: Record findings**
+
+Write the discovered `<MODELS_RESOURCES_DIST_ID>` value and the IAM principal name in a scratch note (e.g., on the CODAP-1366 Jira issue). You'll reference the distribution ID in Task 2. The IAM principal is for documentation / future debugging only.
+
+If any of Steps 1–3 fails, **stop** and resolve the underlying issue before proceeding to Task 2. Don't write the workflow against an environment that can't run it.
+
+---
+
+## Task 2: Write the `ci.yml` workflow file
+
+**Files:**
+- Create: `.github/workflows/ci.yml`
+
+This task assumes Task 1 succeeded and you have the `models-resources` distribution ID handy.
+
+- [ ] **Step 1: Confirm you're on the `CODAP-1366-build-deploy` branch**
+
+Run:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: `CODAP-1366-build-deploy`. If not, switch:
+
+```bash
+git checkout CODAP-1366-build-deploy
+```
+
+- [ ] **Step 2: Create the workflows directory**
+
+Run:
+
+```bash
+mkdir -p .github/workflows
+```
+
+Expected: no output (directory either already exists or is created). Confirm:
+
+```bash
+ls -la .github/workflows/
+```
+
+Expected: empty directory (the repo has no existing workflows — confirmed during exploration).
+
+- [ ] **Step 3: Write `.github/workflows/ci.yml`**
+
+Substitute the `<MODELS_RESOURCES_DIST_ID>` placeholder near the bottom with the real distribution ID you recorded in Task 1 Step 4. Everything else is literal.
+
+```yaml
+name: Continuous Integration
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+
+jobs:
+  build_test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Jest tests
+        run: CI=true npm test -- --watchAll=false
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+      - name: Build
+        run: npm run build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build/
+
+  deploy:
+    name: Deploy to S3
+    needs: build_test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: story-builder-deploy
+      cancel-in-progress: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: build
+
+      - name: Validate tag matches kSBVersion and package.json
+        run: |
+          TAG_VERSION="${TAG#v}"
+          SB_VERSION=$(sed -nE 's/.*kSBVersion = "([^"]+)".*/\1/p' src/models/story_builder.ts)
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
+          if [[ "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::Version mismatch — refusing to deploy."
+            exit 1
+          fi
+
+      - name: Sync to codap-resources (V3 read path)
+        run: |
+          aws s3 sync build/ s3://codap-resources/plugins/story-builder/ \
+            --acl public-read --delete
+
+      - name: Sync to models-resources root (canonical)
+        run: |
+          aws s3 sync build/ s3://models-resources/story-builder/ \
+            --acl public-read --delete \
+            --exclude "version/*"
+
+      - name: Archive to models-resources/version/<tag>/
+        run: |
+          aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ \
+            --acl public-read
+
+      - name: Invalidate CloudFront (codap-resources)
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E1RS9TZVZBEEEC \
+            --paths "/plugins/story-builder/*"
+
+      - name: Invalidate CloudFront (models-resources)
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id <MODELS_RESOURCES_DIST_ID> \
+            --paths "/story-builder/*"
+```
+
+- [ ] **Step 4: Sanity-check the YAML parses**
+
+Run:
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"
+```
+
+Expected: `YAML OK`. If you get a YAMLError, re-check indentation (workflows are sensitive to tabs vs. spaces — the file above uses 2-space indentation throughout).
+
+- [ ] **Step 5: Verify the placeholder was replaced**
+
+Run:
+
+```bash
+grep -n "MODELS_RESOURCES_DIST_ID" .github/workflows/ci.yml
+```
+
+Expected: **no output**. If grep finds the placeholder string, you forgot to substitute it in Step 3.
+
+- [ ] **Step 6: Verify locally that the validation step's bash logic is correct against the *current* mismatched state**
+
+Run the same logic the workflow will run, in your shell, against the working tree (which still has the mismatched versions):
+
+```bash
+TAG_VERSION="0.86"   # simulating a v0.86 tag
+SB_VERSION=$(sed -nE 's/.*kSBVersion = "([^"]+)".*/\1/p' src/models/story_builder.ts)
+PKG_VERSION=$(node -p "require('./package.json').version")
+echo "tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
+```
+
+Expected output:
+
+```
+tag=0.86 kSBVersion=0.86 package.json=0.1.0
+```
+
+This confirms the sed and node lookups work against the real files. The mismatch (`0.86 != 0.1.0`) is the failure mode Stage 1 will exercise.
+
+- [ ] **Step 7: Commit the workflow**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+CODAP-1366: add ci.yml for build + S3 deploy on tag
+
+Build & test on every push to master and every PR. Deploy job
+(tag-only, v*) downloads the build_test artifact, validates that
+kSBVersion + package.json version + tag all agree, then syncs to
+codap-resources/plugins/story-builder/ and to models-resources/
+story-builder/ (root + version/<tag>/ archive), and creates
+CloudFront invalidations on both distributions.
+
+See docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
+for the full design rationale.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Verify:
+
+```bash
+git log --oneline -3
+```
+
+Expected: top commit is `CODAP-1366: add ci.yml for build + S3 deploy on tag`, second commit is `CODAP-1366: design doc for standalone build & deploy` (e1edd75), third is the master HEAD that includes the CODAP-1362 fix.
+
+---
+
+## Task 3: Push the branch and open the PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch to origin**
+
+```bash
+git push -u origin CODAP-1366-build-deploy
+```
+
+Expected: the push succeeds and prints the upstream-tracking message.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --base master \
+  --title "CODAP-1366: standalone build & deploy workflow" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `.github/workflows/ci.yml`: build + Jest test on every push/PR; deploys to S3 + CloudFront on `v*` tag push.
+- Adds the design spec at `docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md` covering rationale, decisions, and commissioning plan.
+- Dual-bucket publish during the V2→V3 transition: `codap-resources/plugins/story-builder/` (current V3 read path) and `models-resources/story-builder/` (org standard + per-tag archive).
+
+## Test plan
+- [ ] Verify `build_test` job runs green on the PR push (CI builds and Jest test passes).
+- [ ] After merge, push `v0.86` tag at master HEAD. Confirm the deploy job's **validation step fails** (master has `kSBVersion = '0.86'` but `package.json` version is still `'0.1.0'`), with no S3 writes.
+- [ ] In follow-up PR, bump `kSBVersion` and `package.json` to `0.87`; tag `v0.87`. Confirm the full deploy succeeds end-to-end and the CODAP-1362 fix is live in V3.
+
+Refs CODAP-1366.
+EOF
+)"
+```
+
+Expected: the command prints the PR URL.
+
+- [ ] **Step 3: Verify `build_test` runs and passes on the PR**
+
+```bash
+gh pr checks  # run in the repo, shows checks for the PR you just opened
+```
+
+Wait for the `Build & Test` job to complete (typically 2–4 minutes). Expected: all checks pass (✓). If `build_test` fails, investigate the logs via `gh run view --log-failed` — common causes: stale lockfile, network issue installing dependencies, a real test failure surfaced by running in CI for the first time. Resolve before requesting review.
+
+- [ ] **Step 4: Request review**
+
+The reviewer should look at both the design spec (for design alignment) and the workflow file (for correctness). The PR body's test plan captures what the reviewer can expect to happen post-merge.
+
+- [ ] **Step 5: After approval, merge**
+
+Squash-merge via the GitHub UI (matches the repo's existing PR style — the CODAP-1362 fix was squash-merged as commit `49acc8b`).
+
+After merging, **stop and proceed to Task 4** in the same context window or session — do not delete the local branch yet; you'll want it for reference.
+
+---
+
+## Task 4: Stage 1 commissioning — verify validation catches mismatch
+
+**Purpose:** Prove that the validation step fails loudly when versions don't match. Master now has `ci.yml`, `kSBVersion = '0.86'`, and `package.json` version `'0.1.0'` — the natural mismatched state from the spec.
+
+**Files:** none (this task only pushes a tag and observes).
+
+- [ ] **Step 1: Switch to master and pull the merged PR**
+
+```bash
+git checkout master
+git pull --ff-only
+```
+
+Expected: master fast-forwards to include the merge commit from Task 3.
+
+- [ ] **Step 2: Confirm the mismatched state is what you expect**
+
+```bash
+grep "kSBVersion" src/models/story_builder.ts
+node -p "require('./package.json').version"
+```
+
+Expected:
+
+```
+export const kSBVersion = "0.86";
+0.1.0
+```
+
+If `package.json` is anything other than `0.1.0`, someone has already aligned it — abort Stage 1 commissioning (the natural mismatch is gone and this test is no longer meaningful). Note that in the Jira issue and move on to Task 5.
+
+- [ ] **Step 3: Tag `v0.86` at master HEAD and push**
+
+```bash
+git tag v0.86
+git push origin v0.86
+```
+
+Expected: the tag push triggers a workflow run. Find it:
+
+```bash
+gh run list --workflow=ci.yml --limit 3
+```
+
+The most recent run should show `tag` as its event (or `push` with a `refs/tags/v0.86` ref). Wait ~30 seconds for the job to be scheduled if it doesn't appear immediately.
+
+- [ ] **Step 4: Watch the workflow run and confirm validation fails**
+
+```bash
+gh run watch  # picks up the most recent run; or pass the run ID
+```
+
+Expected:
+- `Build & Test` job succeeds (the source compiles and the test passes; nothing is wrong with the code at this commit).
+- `Deploy to S3` job runs the validation step, prints `tag=0.86 kSBVersion=0.86 package.json=0.1.0`, then the `::error::Version mismatch — refusing to deploy.` annotation, and exits non-zero.
+- **No subsequent S3 sync or CloudFront step runs** (because validation failed).
+
+- [ ] **Step 5: Verify nothing was written to S3**
+
+```bash
+aws s3 ls s3://codap-resources/plugins/story-builder/ --recursive | head -5
+aws s3 ls s3://models-resources/story-builder/ --recursive | head -5 2>&1 || echo "(no objects yet — expected)"
+```
+
+Expected: `codap-resources/plugins/story-builder/` shows the existing V2-rsync'd content (last-modified timestamps from the most recent V2 build, *not* from the last few minutes). `models-resources/story-builder/` may not exist yet (nothing was deployed there before) and that's fine.
+
+- [ ] **Step 6: Confirm the tag is a legitimate marker for the current production code**
+
+Leave the `v0.86` tag in place — it correctly marks the current `kSBVersion = '0.86'` commit on master. It is not deleted as part of Stage 1.
+
+- [ ] **Step 7: Record the Stage 1 result**
+
+Note in the CODAP-1366 Jira issue: "Stage 1 commissioning complete. `v0.86` tag pushed; deploy job's validation step fired as expected, exited non-zero, no S3 writes." Link to the failed workflow run URL.
+
+If Stage 1 didn't fail as expected (e.g., validation step passed unexpectedly, or sync steps ran), **stop**. The validation logic has a bug. Fix it in a follow-up PR before proceeding to Task 5.
+
+---
+
+## Task 5: Stage 2 PR — bump versions to `0.87`
+
+**Files:**
+- Modify: `src/models/story_builder.ts:6`
+- Modify: `package.json:3`
+
+This PR ships the CODAP-1362 fix (already on master) as version `0.87`.
+
+- [ ] **Step 1: Branch off master**
+
+```bash
+git checkout master   # should already be here from Task 4
+git pull --ff-only    # sanity
+git checkout -b CODAP-1366-release-0.87
+```
+
+- [ ] **Step 2: Bump `kSBVersion`**
+
+Edit `src/models/story_builder.ts` line 6:
+
+Find:
+```typescript
+export const kSBVersion = "0.86";
+```
+
+Replace with:
+```typescript
+export const kSBVersion = "0.87";
+```
+
+Verify:
+
+```bash
+grep "kSBVersion" src/models/story_builder.ts
+```
+
+Expected: `export const kSBVersion = "0.87";`
+
+- [ ] **Step 3: Bump `package.json` version**
+
+Edit `package.json` line 3 (the `"version"` field at the top of the file).
+
+Find:
+```json
+  "version": "0.1.0",
+```
+
+Replace with:
+```json
+  "version": "0.87",
+```
+
+Verify:
+
+```bash
+node -p "require('./package.json').version"
+```
+
+Expected: `0.87`
+
+- [ ] **Step 4: Sanity-check the build still works locally**
+
+```bash
+NODE_OPTIONS=--openssl-legacy-provider npm test -- --watchAll=false
+NODE_OPTIONS=--openssl-legacy-provider npm run build
+```
+
+Expected: tests pass; build completes; `build/` directory populated. If build fails for an unrelated reason (e.g., toolchain quirk in your env), abort and investigate before pushing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/story_builder.ts package.json
+git commit -m "$(cat <<'EOF'
+CODAP-1366: release version 0.87
+
+Bump kSBVersion to 0.87 and align package.json (long-stale at
+0.1.0) to the same value. This is the first release that ships
+through the new ci.yml deploy workflow and the first release that
+includes the CODAP-1362 fix (PR #2, merged 49acc8b).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: Push and open the PR**
+
+```bash
+git push -u origin CODAP-1366-release-0.87
+gh pr create \
+  --base master \
+  --title "CODAP-1366: release version 0.87" \
+  --body "$(cat <<'EOF'
+## Summary
+- Bumps `kSBVersion` from `0.86` to `0.87` and aligns `package.json` `version` (long-stale at `0.1.0`) to `0.87`.
+- First release through the new `ci.yml` deploy workflow (introduced in CODAP-1366).
+- First release that includes the CODAP-1362 fix (PR #2).
+
+## Test plan
+- [ ] CI build + test passes on this PR.
+- [ ] After merge, tag `v0.87` at the new HEAD. Confirm the deploy job validates successfully, syncs to both buckets + the `version/v0.87/` archive, and creates both CloudFront invalidations.
+- [ ] Confirm CODAP V3 picks up the new build (CODAP-1362 fix verifiable: adding Story Builder to a v3 doc, then a graph, dirties the moment).
+
+Refs CODAP-1366.
+EOF
+)"
+```
+
+- [ ] **Step 7: Verify `build_test` passes on the PR**
+
+```bash
+gh pr checks
+```
+
+Expected: `Build & Test` ✓. If it fails, investigate before requesting review.
+
+- [ ] **Step 8: Request review and squash-merge once approved**
+
+After merging, continue to Task 6 to push the tag.
+
+---
+
+## Task 6: Stage 2 commissioning — live deploy of `v0.87`
+
+**Purpose:** Push the `v0.87` tag, watch the full deploy run, verify the artifacts land in S3 and CloudFront is invalidated.
+
+**Files:** none.
+
+- [ ] **Step 1: Switch to master and pull the merged release PR**
+
+```bash
+git checkout master
+git pull --ff-only
+```
+
+Expected: master fast-forwards to include the `0.87` bump commit.
+
+- [ ] **Step 2: Confirm versions are aligned**
+
+```bash
+grep "kSBVersion" src/models/story_builder.ts
+node -p "require('./package.json').version"
+```
+
+Expected:
+
+```
+export const kSBVersion = "0.87";
+0.87
+```
+
+- [ ] **Step 3: Tag `v0.87` and push**
+
+```bash
+git tag v0.87
+git push origin v0.87
+```
+
+- [ ] **Step 4: Watch the workflow run end-to-end**
+
+```bash
+gh run list --workflow=ci.yml --limit 3
+gh run watch
+```
+
+Expected sequence (~3–5 minutes total):
+1. `Build & Test` job: succeeds (artifact uploaded).
+2. `Deploy to S3` job validation step: prints `tag=0.87 kSBVersion=0.87 package.json=0.87`, no error.
+3. `Sync to codap-resources` step: completes, lists uploaded files.
+4. `Sync to models-resources root` step: completes.
+5. `Archive to models-resources/version/<tag>/` step: completes.
+6. `Invalidate CloudFront (codap-resources)` step: completes; prints an invalidation ID.
+7. `Invalidate CloudFront (models-resources)` step: completes; prints an invalidation ID.
+
+If any step fails, the spec's Error Handling section applies — re-run the failed job from the Actions UI (`gh run rerun <run-id> --failed`).
+
+- [ ] **Step 5: Verify S3 contents at all three target prefixes**
+
+```bash
+aws s3 ls s3://codap-resources/plugins/story-builder/ --recursive | head -20
+aws s3 ls s3://models-resources/story-builder/ --recursive | head -20
+aws s3 ls s3://models-resources/story-builder/version/v0.87/ --recursive | head -20
+```
+
+Expected: all three list builds with recent LastModified timestamps (within the last few minutes). The contents should match `build/` from a local `npm run build` — at a minimum, `index.html`, `asset-manifest.json`, `static/js/main.*.js`, `static/css/main.*.css`.
+
+- [ ] **Step 6: Verify both CloudFront invalidations completed**
+
+```bash
+aws cloudfront list-invalidations --distribution-id E1RS9TZVZBEEEC --max-items 3
+aws cloudfront list-invalidations --distribution-id <MODELS_RESOURCES_DIST_ID> --max-items 3
+```
+
+Expected: the most recent invalidation on each distribution has `Status: Completed` (or `InProgress` if you check within a minute). Note the IDs — they'll typically match what step 4 printed.
+
+- [ ] **Step 7: Smoke-test in CODAP V3 (functional verification)**
+
+Open a CODAP V3 instance (typically `https://codap3.concord.org/` or your local v3 dev server pointing at production resources). Add Story Builder to a new document. Confirm:
+
+1. Story Builder loads (no 404, no script errors in the console — the plugin URL resolves to the freshly synced `codap-resources/plugins/story-builder/` content).
+2. The CODAP-1362 fix is present: with Story Builder added, add a graph; the first moment turns yellow (dirty). This is the user-visible bug fix this whole release is shipping.
+
+If Story Builder loads but the CODAP-1362 fix isn't present, the most likely cause is CloudFront serving stale cached HTML. Wait 1–2 minutes for invalidation to propagate, then hard-refresh. If it persists, manually invalidate again via `aws cloudfront create-invalidation --distribution-id E1RS9TZVZBEEEC --paths "/plugins/story-builder/*"`.
+
+- [ ] **Step 8: Record Stage 2 result**
+
+Note in the CODAP-1366 Jira issue: "Stage 2 commissioning complete. `v0.87` tag pushed; full deploy succeeded; CODAP-1362 fix verified live in V3." Link to the successful workflow run URL and the relevant CloudFront invalidation IDs.
+
+Also update CODAP-1362's Jira issue to "Deployed" (or your team's equivalent status) and note that the fix is live as of `v0.87`.
+
+---
+
+## Task 7: Close out and clean up
+
+**Files:** none.
+
+- [ ] **Step 1: Delete the local branches you no longer need**
+
+```bash
+git branch -d CODAP-1366-build-deploy
+git branch -d CODAP-1366-release-0.87
+```
+
+Expected: branches delete cleanly (both have been merged to master).
+
+- [ ] **Step 2: Confirm `gh pr list` shows both PRs as merged**
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+Expected: both `CODAP-1366: standalone build & deploy workflow` and `CODAP-1366: release version 0.87` appear in the merged-recently list.
+
+- [ ] **Step 3: Move the Jira issue to Done**
+
+In the CODAP-1366 Jira UI, transition the story to `Done` (or your team's equivalent terminal status). Include a brief summary comment: "Workflow shipped (PR #N). v0.87 deployed via the new pipeline; CODAP-1362 fix live."
+
+- [ ] **Step 4: Update the README to mention the new release process**
+
+`README.md` currently describes the dev/test setup but doesn't mention how releases ship. Worth a small follow-up PR to document the version-bump-and-tag flow — but **defer this to a separate task**; not in scope for CODAP-1366. Add an issue or a TODO if your team tracks docs work separately.
+
+---
+
+## Verification summary
+
+If everything above succeeded, the following observable end-state is true:
+
+- `.github/workflows/ci.yml` exists on master.
+- `kSBVersion = "0.87"` in `src/models/story_builder.ts`; `package.json` `version` is `"0.87"`.
+- Tags `v0.86` (Stage 1 marker) and `v0.87` (live release) both exist on origin.
+- The GitHub Actions run for `v0.87` shows all seven deploy-job steps as green.
+- `s3://codap-resources/plugins/story-builder/`, `s3://models-resources/story-builder/`, and `s3://models-resources/story-builder/version/v0.87/` all contain the new build.
+- CODAP V3, loaded fresh, exhibits the CODAP-1362 fix.
+
+The next time someone wants to ship story-builder, the steady-state flow is just: bump kSBVersion + package.json in a PR, merge, tag `v<version>`, push tag.

--- a/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
@@ -31,7 +31,7 @@ Out of scope:
 | Deploy targets | Both `s3://models-resources/story-builder/` and `s3://codap-resources/plugins/story-builder/` |
 | `models-resources` layout | Tag → root + `version/<tag>/` archive |
 | `codap-resources` layout | Tag → root only (overwrite in place) |
-| Trigger | GitHub Actions on tag push matching `v*` |
+| Trigger | GitHub Actions on tag push matching `v[0-9]*` (tighter than `v*` so stray non-version tags like `vibe-check` don't fire deploy) |
 | Versioning | Developer bumps `kSBVersion` *and* `package.json` `version` in a PR; tag matches; workflow validates all three agree |
 | CI scope | Build + Jest test on every push/PR; deploy job gated by tag |
 | Workflow file | Single `.github/workflows/ci.yml` (org convention) |
@@ -77,7 +77,7 @@ The repo's PR convention drives the version-bump cadence:
 2. Review and merge to `master`.
 3. Tag the merge commit: `git tag v0.87 && git push --tags`.
 
-Tag format is `v<semver>` (e.g., `v0.87`), matching the workflow's `'v*'` tag filter and the `v` prefix convention common in the org.
+Tag format is `v<semver>` (e.g., `v0.87`), matching the workflow's `'v[0-9]*'` tag filter and the `v` prefix convention common in the org.
 
 The workflow validates and never writes back to the repo. Forgetting to bump shows up as a failed CI run — recoverable by a small follow-up PR, then a fresh tag.
 

--- a/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
@@ -36,10 +36,11 @@ Out of scope:
 | CI scope | Build + Jest test on every push/PR; deploy job gated by tag |
 | Workflow file | Single `.github/workflows/ci.yml` (org convention) |
 | Sync mechanism | Plain `aws s3 sync --delete` (no `--size-only`) — correct in CI because build mtimes are always fresh |
-| CloudFront invalidation | Automatic, last step of deploy job |
+| CloudFront invalidation | Not used. Cache strategy below makes invalidation unnecessary. |
 | Concurrency | `concurrency: { group: story-builder-deploy, cancel-in-progress: false }` on the deploy job to serialize tag races |
 | AWS authentication | GitHub OIDC → IAM role assumption via `aws-actions/configure-aws-credentials@v4`. No long-lived secrets. Role: `arn:aws:iam::612297603577:role/story-builder`, set up via `concord-consortium/starter-projects/scripts/create-deploy-role.sh`. |
-| IAM policy | Shared managed policy `S3-deploy-by-role-tag` (covers `models-resources/story-builder/*` via RepoName tag) + supplemental inline policy for `codap-resources/plugins/story-builder/*` writes and `cloudfront:CreateInvalidation` on both distributions. |
+| IAM policy | Shared managed policy `S3-deploy-by-role-tag` (covers `models-resources/story-builder/*` via RepoName tag) + supplemental inline policy for `codap-resources/plugins/story-builder/*` writes. No CloudFront permission needed — see Cache strategy. |
+| Cache strategy | Per-file `Cache-Control` headers set at upload time. Hashed assets (`build/static/*`): `public, max-age=31536000, immutable`. HTML and root manifests: `no-cache, no-store, must-revalidate`. No `aws cloudfront create-invalidation` step — CloudFront honors origin `Cache-Control` (verified: both distributions use cache policy `S3-CORS-1` with MinTTL=1, so `no-cache` is respected). |
 | Generalization to other plugins | None for now — copy-paste when needed |
 
 ## Workflow architecture
@@ -159,37 +160,43 @@ steps:
   # Archive first so canonical URLs are never updated without a matching archive.
   - name: Archive to models-resources/version/<tag>/
     run: |
-      aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete
+      aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete \
+        --cache-control "public, max-age=31536000, immutable"
 
-  - name: Sync to codap-resources (v3 read path)
+  # Canonical syncs — two-step per target: hashed assets first (additive,
+  # long-cache), then HTML/manifests (with --delete, no-cache).
+
+  - name: Sync hashed assets to codap-resources
     run: |
-      aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete
+      aws s3 sync build/static/ s3://codap-resources/plugins/story-builder/static/ \
+        --cache-control "public, max-age=31536000, immutable"
+  - name: Sync HTML/manifests to codap-resources
+    run: |
+      aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete \
+        --exclude "static/*" \
+        --cache-control "no-cache, no-store, must-revalidate"
 
-  - name: Sync to models-resources root (canonical)
+  - name: Sync hashed assets to models-resources root
+    run: |
+      aws s3 sync build/static/ s3://models-resources/story-builder/static/ \
+        --cache-control "public, max-age=31536000, immutable"
+  - name: Sync HTML/manifests to models-resources root
     run: |
       aws s3 sync build/ s3://models-resources/story-builder/ --delete \
-        --exclude "version/*"
-
-  - name: Invalidate CloudFront (codap-resources)
-    run: |
-      aws cloudfront create-invalidation \
-        --distribution-id E1RS9TZVZBEEEC \
-        --paths "/plugins/story-builder/*"
-
-  - name: Invalidate CloudFront (models-resources)
-    run: |
-      aws cloudfront create-invalidation \
-        --distribution-id <MODELS_RESOURCES_DIST_ID> \
-        --paths "/story-builder/*"
+        --exclude "static/*" --exclude "version/*" \
+        --cache-control "no-cache, no-store, must-revalidate"
 ```
 
 Flag rationale:
 - **No `--size-only` anywhere.** In CI, build artifacts always have fresh mtimes (newer than any prior S3 LastModified), so plain `aws s3 sync` uploads everything that has changed by mtime — which, in CI, is effectively the whole build. Cost: a few MB of bandwidth per release. Benefit: avoids the documented bug where `--size-only` misses content changes that happen to preserve file size (e.g., `index.html` with a swapped hashed-asset reference).
-- **`--delete` on all three syncs** (including the version archive) so removed or renamed bundle files don't linger anywhere, even on a force-pushed tag re-deploy.
+- **`--delete` on the archive and on the HTML/manifest syncs.** The archive sync uses `--delete` so a force-pushed tag re-deploy doesn't leave orphan files in the version-pinned path. The HTML/manifest sync uses `--delete --exclude "static/*"` so removed root-level files (HTML, manifests) are purged without touching the hashed-asset subtree.
+- **Hashed-asset syncs intentionally omit `--delete`.** Old hashed assets linger to support cached old HTML that may still reference them. Filenames change with content, so accumulation is incremental and slow; periodic pruning is future work (see Known limitations).
 - **`--exclude "version/*"`** on the models-resources root sync so the version archive isn't wiped. (No `--exclude "branch/*"` — we don't deploy branches.)
+- **`--cache-control` per sync.** Hashed assets and immutable archives use `public, max-age=31536000, immutable`. HTML and root manifests use `no-cache, no-store, must-revalidate`. Both CloudFront distributions use cache policy `S3-CORS-1` (MinTTL=1, DefaultTTL=86400, MaxTTL=31536000), so origin `Cache-Control` is fully respected at the edge. Browser caches also respect these headers, eliminating the failure mode where a cached old HTML references a deleted hashed asset.
+- **No `aws cloudfront create-invalidation`.** Because origin `Cache-Control` is respected, new HTML is served immediately (no-cache) and new hashed assets are referenced by new HTML (immutable + content-addressed). Invalidations are redundant and only affect CloudFront — they would NOT clear browser caches, which the cache-control headers do address.
 - **No `--acl public-read`.** Both buckets have bucket policies that grant `s3:GetObject` to `Principal: *` on all objects, so per-object ACLs are redundant. Dropping the flag also makes the workflow robust against future moves to `BucketOwnerEnforced` ownership (AWS's recommended default for new buckets, which disables per-object ACLs and would cause `--acl public-read` to fail at PUT time).
 
-Step order: **write the version archive first**, then sync codap-resources, then sync models-resources root, then invalidate codap-resources CloudFront, then invalidate models-resources CloudFront. Archive-first means the canonical URLs are never updated without a corresponding archive existing — a partial failure between archive and canonical leaves the version archive present but the canonical still serving the previous release, which is a recoverable state. CloudFront invalidations run last so a partial failure earlier in the deploy leaves the old (cached) build serving until the run is recovered.
+Step order: **write the version archive first**, then per canonical target sync hashed assets (additive, long-cache) then HTML/manifests (`--delete`, no-cache). Archive-first means the canonical URLs are never updated without a corresponding archive existing — a partial failure between archive and canonical leaves the version archive present but the canonical still serving the previous release, which is a recoverable state. Within each canonical target, hashed-assets-first means new asset filenames exist before new HTML references them, eliminating any window where new HTML would point at not-yet-uploaded assets.
 
 ### Defensive flags
 
@@ -204,7 +211,7 @@ Step order: **write the version archive first**, then sync codap-resources, then
 
 - **No concurrency group on `build_test`.** Two tags pushed close together create two independent `build_test` runs in parallel; whichever finishes first enters the `deploy` queue first. In the pathological case where `build_test` ordering inverts the push order, the older tag's deploy runs second and overwrites the newer tag's canonical content. Mitigation: don't push tags faster than `build_test` completes (~2 minutes). Adding concurrency to `build_test` would also serialize PR builds against tag deploys, hurting iteration; the trade-off doesn't favor protecting against a corner case that's unlikely under normal release cadence.
 - **Trigger duplication on tagged releases.** Pushing a commit to master AND pushing a release tag at that commit fires two parallel `build_test` runs (one for `push:master`, one for `push:tags`). CI cost only; no correctness impact.
-- **CloudFront `/story-builder/*` invalidation pattern is wider than strictly needed.** It also invalidates the immutable per-version archive paths. Within CloudFront's free 1000-paths-per-month quota; tightening to a list of specific paths (`/story-builder/index.html`, `/story-builder/static/*`, etc.) is brittle as the build output evolves.
+- **Orphaned hashed assets in `static/`.** Canonical hashed-asset syncs intentionally omit `--delete` so cached old HTML can still reference old assets without 404ing. Over many releases this accumulates orphans in `s3://codap-resources/plugins/story-builder/static/` and `s3://models-resources/story-builder/static/`. The accumulation is slow (~tens of KB per release for unchanged libraries, more for libraries that change), and S3 storage is cheap. A periodic prune job (e.g., delete files older than N days) is future work.
 
 ## Error handling
 
@@ -221,18 +228,9 @@ The validation step runs before any AWS call, so a mismatch fails loud with zero
 
 ### Partial-deploy failures
 
-The three S3 sync steps run sequentially. If a later step fails, earlier writes have already happened, but CloudFront invalidation is the *last* step — so users keep seeing the cached old build until the run is recovered. Not a broken state, just an incomplete one.
+The S3 sync steps run sequentially: archive → codap-resources static → codap-resources HTML → models-resources static → models-resources HTML. If a later step fails, earlier writes have already happened. The archive-first ordering ensures the immutable version snapshot exists before any canonical URL is updated. Within each canonical target, hashed-asset-first ordering ensures new asset filenames exist before new HTML references them. A partial failure between targets leaves one canonical URL serving the new release and the other still serving the previous release — a recoverable state, not a broken one.
 
-Recovery: re-run the failed job from the Actions UI. The artifact from `build_test` is preserved, so the re-run uses byte-identical bits. All sync and invalidation operations are idempotent. No new commit, no new tag.
-
-### CloudFront invalidation failures
-
-If S3 writes succeed but invalidation fails, users keep seeing the old build until invalidation succeeds. Two recovery paths:
-
-1. Re-run the invalidation step from the Actions UI.
-2. Invalidate manually via the `/codap-resources` skill or `aws cloudfront create-invalidation` directly.
-
-Invalidation is idempotent — running it twice is fine, just costs a second request.
+Recovery: re-run the failed job from the Actions UI. The artifact from `build_test` is preserved, so the re-run uses byte-identical bits. All sync operations are idempotent — re-uploading the same content with the same `Cache-Control` is a no-op. No new commit, no new tag.
 
 ### Tag-race protection
 
@@ -265,15 +263,15 @@ After the introducing PR merges, master is in a known mismatched state: `kSBVers
 Open a small follow-up PR that aligns both versions to `0.87` (also includes the CODAP-1362 fix already on master from PR #2). Merge. Tag `v0.87` at the new HEAD. The full deploy job runs:
 
 - Validation passes (`tag → 0.87`, `kSBVersion → 0.87`, `package.json → 0.87` all match).
-- All three S3 syncs and both CloudFront invalidations execute against production.
-- Verify by `aws s3 ls` against each prefix, by checking the two CloudFront distributions' recent invalidations, and by loading the new build in a CODAP V3 instance and confirming the CODAP-1362 fix is live.
+- All five S3 syncs execute against production (archive + two canonicals × two sync steps each).
+- Verify by `aws s3 ls` against each prefix, by checking `Cache-Control` headers on a sample of objects (`aws s3api head-object`), and by loading the new build in a CODAP V3 instance and confirming the CODAP-1362 fix is live.
 
 Stage 2 is also the real first ship of the bugfix, so commissioning and shipping are one act. If anything in Stage 2 fails (AWS creds, IAM, CloudFront perms), the fix is to address that underlying issue and re-run the workflow from the Actions UI.
 
 ### Not tested in this design
 
 - Workflow YAML syntax beyond what GitHub validates on push (`actionlint` is overkill for ~80 lines of workflow).
-- CloudFront propagation latency (operational expectation; ~1 minute after invalidation).
+- CloudFront edge propagation (operational expectation; new `Cache-Control: no-cache` HTML reaches all edges within ~seconds, much faster than a manual invalidation would have).
 - Cross-version regressions on the V2 side (manual functional check during commissioning).
 
 ## Prerequisites
@@ -285,7 +283,6 @@ Stage 2 is also the real first ship of the bugfix, so commissioning and shipping
    - **b.** Attach a supplemental inline policy to the same role covering the things the shared policy doesn't:
      - `s3:PutObject`, `s3:DeleteObject` on `arn:aws:s3:::codap-resources/plugins/story-builder/*`
      - `s3:ListBucket` on `arn:aws:s3:::codap-resources` with condition `s3:prefix` like `plugins/story-builder/*` (needed for `aws s3 sync` to list the prefix)
-     - `cloudfront:CreateInvalidation` on distribution `E1RS9TZVZBEEEC` (codap-resources) and `E1QHTGVGYD1DWZ` (models-resources)
    - **c.** Verify by inspecting the new role: `aws iam get-role --role-name story-builder` and `aws iam list-attached-role-policies --role-name story-builder`.
 
    No GitHub repo secrets are required — the workflow uses `aws-actions/configure-aws-credentials@v4` with `role-to-assume` and the OIDC `id-token` permission. `build_test` runs without any AWS involvement.

--- a/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
@@ -38,6 +38,8 @@ Out of scope:
 | Sync mechanism | Plain `aws s3 sync --delete` (no `--size-only`) — correct in CI because build mtimes are always fresh |
 | CloudFront invalidation | Automatic, last step of deploy job |
 | Concurrency | `concurrency: { group: story-builder-deploy, cancel-in-progress: false }` on the deploy job to serialize tag races |
+| AWS authentication | GitHub OIDC → IAM role assumption via `aws-actions/configure-aws-credentials@v4`. No long-lived secrets. Role: `arn:aws:iam::612297603577:role/story-builder`, set up via `concord-consortium/starter-projects/scripts/create-deploy-role.sh`. |
+| IAM policy | Shared managed policy `S3-deploy-by-role-tag` (covers `models-resources/story-builder/*` via RepoName tag) + supplemental inline policy for `codap-resources/plugins/story-builder/*` writes and `cloudfront:CreateInvalidation` on both distributions. |
 | Generalization to other plugins | None for now — copy-paste when needed |
 
 ## Workflow architecture
@@ -116,14 +118,14 @@ Notes:
 needs: build_test
 if: startsWith(github.ref, 'refs/tags/v')
 runs-on: ubuntu-latest
+permissions:
+  id-token: write                # required for OIDC token issuance
+  contents: read
 concurrency:
   group: story-builder-deploy
   cancel-in-progress: false
 env:
-  AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION:    us-east-1
-  TAG:                   ${{ github.ref_name }}      # e.g., "v0.87"
+  TAG: ${{ github.ref_name }}    # e.g., "v0.87"
 steps:
   - uses: actions/checkout@v4                        # need source for validation step
   - uses: actions/download-artifact@v4
@@ -138,6 +140,11 @@ steps:
         echo "Version mismatch: tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
         exit 1
       fi
+
+  - uses: aws-actions/configure-aws-credentials@v4
+    with:
+      role-to-assume: arn:aws:iam::612297603577:role/story-builder
+      aws-region: us-east-1
 
   - name: Sync to codap-resources (v3 read path)
     run: |
@@ -248,14 +255,18 @@ Stage 2 is also the real first ship of the bugfix, so commissioning and shipping
 
 ### Verify before the first deploy (blocking)
 
-1. **AWS GitHub secrets accessible to `concord-consortium/story-builder`.** ⚠️ **Confirmed missing as of 2026-05-26** — neither `AWS_ACCESS_KEY_ID` nor `AWS_SECRET_ACCESS_KEY` is inherited from the org. Other plugin repos (e.g., `noaa-codap-plugin`) use these names, so they exist *somewhere* — likely scoped to specific repos rather than org-wide. Coordinate with the AWS admin to provision the secrets for `story-builder`: org-level inheritance, repo-level secrets, or a GitHub Environment. The IAM principal those creds back must grant the perms in (2). Build-test runs on PR push without secrets, so the workflow can be merged first and the deploy job will simply not work until the secrets land.
-2. **IAM policy for the role those creds back.** Must grant:
-   - `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` on `codap-resources/plugins/story-builder/*`
-   - Same three on `models-resources/story-builder/*`
-   - `cloudfront:CreateInvalidation` on the codap-resources distribution (`E1RS9TZVZBEEEC`)
-   - `cloudfront:CreateInvalidation` on the models-resources distribution (`E1QHTGVGYD1DWZ`)
-3. **Bucket public-read access.** ✅ **Confirmed 2026-05-26:** both `codap-resources` and `models-resources` have bucket policies that grant `s3:GetObject` to `Principal: *`, so all uploaded objects are publicly readable by default. No `--acl public-read` flag is needed on the AWS CLI commands.
-4. **GitHub Actions enabled** on the story-builder repo (default for org repos; verify the setting is on).
+1. **AWS authentication via OIDC.** No long-lived secrets — story-builder follows the org's current pattern: GitHub OIDC → IAM role assumption. **Setup steps**, run by someone with IAM admin in account `612297603577`:
+   - **a.** From a checkout of `concord-consortium/starter-projects` (or this repo, since the script is self-contained), run `./scripts/create-deploy-role.sh story-builder`. This creates IAM role `story-builder`, tags it `RepoName=story-builder`, sets a trust policy that limits assumption to workflows in `concord-consortium/story-builder`, and attaches the shared managed policy `S3-deploy-by-role-tag` (which covers `s3://models-resources/story-builder/*` via the `RepoName` tag).
+   - **b.** Attach a supplemental inline policy to the same role covering the things the shared policy doesn't:
+     - `s3:PutObject`, `s3:DeleteObject` on `arn:aws:s3:::codap-resources/plugins/story-builder/*`
+     - `s3:ListBucket` on `arn:aws:s3:::codap-resources` with condition `s3:prefix` like `plugins/story-builder/*` (needed for `aws s3 sync` to list the prefix)
+     - `cloudfront:CreateInvalidation` on distribution `E1RS9TZVZBEEEC` (codap-resources) and `E1QHTGVGYD1DWZ` (models-resources)
+   - **c.** Verify by inspecting the new role: `aws iam get-role --role-name story-builder` and `aws iam list-attached-role-policies --role-name story-builder`.
+
+   No GitHub repo secrets are required — the workflow uses `aws-actions/configure-aws-credentials@v4` with `role-to-assume` and the OIDC `id-token` permission. `build_test` runs without any AWS involvement.
+
+2. **Bucket public-read access.** ✅ **Confirmed 2026-05-26:** both `codap-resources` and `models-resources` have bucket policies that grant `s3:GetObject` to `Principal: *`, so all uploaded objects are publicly readable by default. No `--acl public-read` flag is needed on the AWS CLI commands.
+3. **GitHub Actions enabled** on the story-builder repo (default for org repos; verify the setting is on).
 
 ### Values resolved
 

--- a/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
@@ -141,19 +141,16 @@ steps:
 
   - name: Sync to codap-resources (v3 read path)
     run: |
-      aws s3 sync build/ s3://codap-resources/plugins/story-builder/ \
-        --acl public-read --delete
+      aws s3 sync build/ s3://codap-resources/plugins/story-builder/ --delete
 
   - name: Sync to models-resources root (canonical)
     run: |
-      aws s3 sync build/ s3://models-resources/story-builder/ \
-        --acl public-read --delete \
+      aws s3 sync build/ s3://models-resources/story-builder/ --delete \
         --exclude "version/*"
 
   - name: Archive to models-resources/version/<tag>/
     run: |
-      aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ \
-        --acl public-read
+      aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/
 
   - name: Invalidate CloudFront (codap-resources)
     run: |
@@ -173,7 +170,7 @@ Flag rationale:
 - **`--delete`** on the two "live" sync targets so removed or renamed bundle files don't linger.
 - **`--exclude "version/*"`** on the models-resources root sync so the version archive isn't wiped. (No `--exclude "branch/*"` — we don't deploy branches.)
 - **Version-archive sync omits `--delete`** because it's a write to a fresh path.
-- **`--acl public-read`** matches the existing bucket convention; assumes ACLs remain enabled on both buckets (see Prerequisites).
+- **No `--acl public-read`.** Both buckets have bucket policies that grant `s3:GetObject` to `Principal: *` on all objects, so per-object ACLs are redundant. Dropping the flag also makes the workflow robust against future moves to `BucketOwnerEnforced` ownership (AWS's recommended default for new buckets, which disables per-object ACLs and would cause `--acl public-read` to fail at PUT time).
 
 Step order: sync codap-resources, sync models-resources root, write version archive, invalidate codap-resources CloudFront, invalidate models-resources CloudFront. CloudFront invalidations run last so a partial failure earlier in the deploy leaves the old (cached) build serving until the run is recovered.
 
@@ -251,19 +248,19 @@ Stage 2 is also the real first ship of the bugfix, so commissioning and shipping
 
 ### Verify before the first deploy (blocking)
 
-1. **AWS GitHub secrets accessible to `concord-consortium/story-builder`.** Org-level `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` exist and are inherited. (Org-level is the assumption based on other repos; if they turn out to be repo-level elsewhere, provision them here.)
+1. **AWS GitHub secrets accessible to `concord-consortium/story-builder`.** ⚠️ **Confirmed missing as of 2026-05-26** — neither `AWS_ACCESS_KEY_ID` nor `AWS_SECRET_ACCESS_KEY` is inherited from the org. Other plugin repos (e.g., `noaa-codap-plugin`) use these names, so they exist *somewhere* — likely scoped to specific repos rather than org-wide. Coordinate with the AWS admin to provision the secrets for `story-builder`: org-level inheritance, repo-level secrets, or a GitHub Environment. The IAM principal those creds back must grant the perms in (2). Build-test runs on PR push without secrets, so the workflow can be merged first and the deploy job will simply not work until the secrets land.
 2. **IAM policy for the role those creds back.** Must grant:
    - `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` on `codap-resources/plugins/story-builder/*`
    - Same three on `models-resources/story-builder/*`
    - `cloudfront:CreateInvalidation` on the codap-resources distribution (`E1RS9TZVZBEEEC`)
-   - `cloudfront:CreateInvalidation` on the models-resources distribution (ID TBD)
-3. **Bucket ACL configuration.** Both buckets must permit `--acl public-read` writes. Newer S3 buckets default to "ACLs disabled" (bucket-owner-enforced ownership), which makes `--acl public-read` fail at PUT time. If either bucket has ACLs disabled, either re-enable them or switch to bucket-policy-based public access and drop `--acl public-read` from the workflow.
+   - `cloudfront:CreateInvalidation` on the models-resources distribution (`E1QHTGVGYD1DWZ`)
+3. **Bucket public-read access.** ✅ **Confirmed 2026-05-26:** both `codap-resources` and `models-resources` have bucket policies that grant `s3:GetObject` to `Principal: *`, so all uploaded objects are publicly readable by default. No `--acl public-read` flag is needed on the AWS CLI commands.
 4. **GitHub Actions enabled** on the story-builder repo (default for org repos; verify the setting is on).
 
-### Values still to look up
+### Values resolved
 
-1. **CloudFront distribution ID for `models-resources`.** Workflow has a `<MODELS_RESOURCES_DIST_ID>` placeholder; resolve via `aws cloudfront list-distributions` or by asking the org's AWS maintainer.
-2. **CloudFront serving URL for `models-resources/story-builder/`.** Not blocking for this design (we keep `codap-resources` as the V3 read path), but useful for any eventual V3-side migration.
+- **CloudFront distribution ID for `models-resources`.** `E1QHTGVGYD1DWZ` (serves `models-resources.concord.org` and `resources.models.concord.org`). Resolved 2026-05-26.
+- **CloudFront serving URL for `models-resources/story-builder/`.** `https://models-resources.concord.org/story-builder/` (assuming the standard generic-distribution path layout used by other plugins in that bucket). Not used by V3 today but useful for any eventual migration.
 
 ## Future work (explicitly out of this design)
 

--- a/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
@@ -50,7 +50,7 @@ A single GitHub Actions workflow at `.github/workflows/ci.yml` with two jobs.
 on:
   push:
     branches: [master]
-    tags: ['v*']
+    tags: ['v[0-9]*']
   pull_request:
 
 jobs:
@@ -104,6 +104,7 @@ steps:
     with:
       name: build
       path: build/
+      if-no-files-found: error
 ```
 
 Notes:
@@ -118,9 +119,11 @@ Notes:
 needs: build_test
 if: startsWith(github.ref, 'refs/tags/v')
 runs-on: ubuntu-latest
+timeout-minutes: 15
 permissions:
   id-token: write                # required for OIDC token issuance
   contents: read
+  actions: read                  # required for download-artifact@v4 under restricted permissions
 concurrency:
   group: story-builder-deploy
   cancel-in-progress: false
@@ -134,10 +137,17 @@ steps:
   - name: Validate tag matches kSBVersion and package.json
     run: |
       TAG_VERSION="${TAG#v}"
-      SB_VERSION=$(sed -nE "s/.*kSBVersion = \"([^\"]+)\".*/\1/p" src/models/story_builder.ts)
+      SB_VERSION=$(sed -nE "s/.*kSBVersion = \"([^\"]+)\".*/\1/p" src/models/story_builder.ts | head -1)
       PKG_VERSION=$(node -p "require('./package.json').version")
-      if [[ "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
-        echo "Version mismatch: tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
+      if [[ -z "$SB_VERSION" || -z "$PKG_VERSION" || "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+        echo "Mismatch or empty: tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
+        exit 1
+      fi
+
+  - name: Sanity-check build artifact
+    run: |
+      if [[ ! -s build/index.html ]]; then
+        echo "build/index.html missing or empty — refusing to sync"
         exit 1
       fi
 
@@ -145,6 +155,11 @@ steps:
     with:
       role-to-assume: arn:aws:iam::612297603577:role/story-builder
       aws-region: us-east-1
+
+  # Archive first so canonical URLs are never updated without a matching archive.
+  - name: Archive to models-resources/version/<tag>/
+    run: |
+      aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ --delete
 
   - name: Sync to codap-resources (v3 read path)
     run: |
@@ -154,10 +169,6 @@ steps:
     run: |
       aws s3 sync build/ s3://models-resources/story-builder/ --delete \
         --exclude "version/*"
-
-  - name: Archive to models-resources/version/<tag>/
-    run: |
-      aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/
 
   - name: Invalidate CloudFront (codap-resources)
     run: |
@@ -174,12 +185,26 @@ steps:
 
 Flag rationale:
 - **No `--size-only` anywhere.** In CI, build artifacts always have fresh mtimes (newer than any prior S3 LastModified), so plain `aws s3 sync` uploads everything that has changed by mtime — which, in CI, is effectively the whole build. Cost: a few MB of bandwidth per release. Benefit: avoids the documented bug where `--size-only` misses content changes that happen to preserve file size (e.g., `index.html` with a swapped hashed-asset reference).
-- **`--delete`** on the two "live" sync targets so removed or renamed bundle files don't linger.
+- **`--delete` on all three syncs** (including the version archive) so removed or renamed bundle files don't linger anywhere, even on a force-pushed tag re-deploy.
 - **`--exclude "version/*"`** on the models-resources root sync so the version archive isn't wiped. (No `--exclude "branch/*"` — we don't deploy branches.)
-- **Version-archive sync omits `--delete`** because it's a write to a fresh path.
 - **No `--acl public-read`.** Both buckets have bucket policies that grant `s3:GetObject` to `Principal: *` on all objects, so per-object ACLs are redundant. Dropping the flag also makes the workflow robust against future moves to `BucketOwnerEnforced` ownership (AWS's recommended default for new buckets, which disables per-object ACLs and would cause `--acl public-read` to fail at PUT time).
 
-Step order: sync codap-resources, sync models-resources root, write version archive, invalidate codap-resources CloudFront, invalidate models-resources CloudFront. CloudFront invalidations run last so a partial failure earlier in the deploy leaves the old (cached) build serving until the run is recovered.
+Step order: **write the version archive first**, then sync codap-resources, then sync models-resources root, then invalidate codap-resources CloudFront, then invalidate models-resources CloudFront. Archive-first means the canonical URLs are never updated without a corresponding archive existing — a partial failure between archive and canonical leaves the version archive present but the canonical still serving the previous release, which is a recoverable state. CloudFront invalidations run last so a partial failure earlier in the deploy leaves the old (cached) build serving until the run is recovered.
+
+### Defensive flags
+
+- **`if-no-files-found: error`** on `actions/upload-artifact@v4`. Default is `warn`, which would silently produce an empty artifact if `build/` were ever missing or empty; combined with `aws s3 sync --delete` on the download, that would wipe production. Setting `error` makes the upload step fail loudly instead.
+- **`Sanity-check build artifact` step** before any AWS call. Checks `test -s build/index.html`. Belt-and-suspenders for the same failure mode — if the artifact contents are intact at upload time but somehow truncated or partially-extracted on download, the sync is blocked before it can do damage.
+- **Validation step also fails on empty `kSBVersion` or `package.json` version.** A renamed file or moved constant would produce empty strings; without the empty-check, two empty strings would `==` and validation would pass spuriously. The `head -1` pipe on `sed` also defends against multiple matches (e.g., a stale `// kSBVersion = "0.85"` comment).
+- **`timeout-minutes: 15`** on the deploy job. Default GHA job timeout is 6 hours; a hung AWS call could otherwise burn that whole budget. 15 minutes is well above a normal deploy's runtime (~2 minutes typical).
+- **`actions: read`** on the deploy job's `permissions:` block. Required by `actions/download-artifact@v4` under restricted permissions (any explicit `permissions:` block sets unlisted scopes to `none`, including the `actions` scope the download API uses).
+- **Tag filter `'v[0-9]*'`** (not `'v*'`). Restricts the deploy trigger to tags that look like version markers (`v0.86`, `v1.0.0`, etc.), so stray `v`-prefixed tags like `vibe-check` don't fire the job at all. Validation is still the authoritative check for matching versions, but the tighter glob is a defense-in-depth layer.
+
+### Known limitations (accepted, not fixed)
+
+- **No concurrency group on `build_test`.** Two tags pushed close together create two independent `build_test` runs in parallel; whichever finishes first enters the `deploy` queue first. In the pathological case where `build_test` ordering inverts the push order, the older tag's deploy runs second and overwrites the newer tag's canonical content. Mitigation: don't push tags faster than `build_test` completes (~2 minutes). Adding concurrency to `build_test` would also serialize PR builds against tag deploys, hurting iteration; the trade-off doesn't favor protecting against a corner case that's unlikely under normal release cadence.
+- **Trigger duplication on tagged releases.** Pushing a commit to master AND pushing a release tag at that commit fires two parallel `build_test` runs (one for `push:master`, one for `push:tags`). CI cost only; no correctness impact.
+- **CloudFront `/story-builder/*` invalidation pattern is wider than strictly needed.** It also invalidates the immutable per-version archive paths. Within CloudFront's free 1000-paths-per-month quota; tightening to a list of specific paths (`/story-builder/index.html`, `/story-builder/static/*`, etc.) is brittle as the build output evolves.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md
@@ -1,0 +1,280 @@
+# Story Builder: standalone build & deploy design
+
+**Date:** 2026-05-26
+**Jira:** [CODAP-1366](https://concord-consortium.atlassian.net/browse/CODAP-1366)
+**Status:** Approved design; ready for implementation plan
+
+## Problem
+
+Until now, story-builder has been deployed to production as part of the CODAP v2 build pipeline (`/codap-v2-build` skill in the codap repo), which assembles seven repositories on a developer's workstation and pushes to `codap-server.concord.org`. CODAP v3 reads plugins from a separate S3 bucket (`codap-resources`) that is currently populated by a *manual* rsync from the v2 build's `extn/plugins/` directory — managed by the `/codap-resources` skill. Both paths are heavy, manual, and bottlenecked on the v2 release cadence.
+
+With the v3 release approaching, we need to be able to build and deploy story-builder (and eventually other standalone plugins) independently of the v2 build process. The first immediate use case is shipping the CODAP-1362 fix (PR #2) without waiting for the next v2 build.
+
+## Scope
+
+In scope:
+- A GitHub Actions workflow in `concord-consortium/story-builder` that builds and deploys to S3 on tag push.
+- Dual-bucket publish during the v2→v3 transition: both `models-resources/story-builder/` (org-standard layout) and `codap-resources/plugins/story-builder/` (the bucket v3 currently reads from).
+- Standard CI (build + Jest tests) on every push and PR.
+
+Out of scope:
+- Migration of other plugins to this pattern (intentionally not generalized — copy-paste the workflow when a second plugin needs it).
+- Retiring `bin/deploy_v7` and `bin/deploy_v8` (legacy V2 endpoints; decide later).
+- Refactoring `kSBVersion` to derive from `package.json` (deferred).
+- Modernizing the toolchain enough to drop `--openssl-legacy-provider` (separate concern).
+- Branch / preview deploys (deferred; recipe noted under "Future work").
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Deploy targets | Both `s3://models-resources/story-builder/` and `s3://codap-resources/plugins/story-builder/` |
+| `models-resources` layout | Tag → root + `version/<tag>/` archive |
+| `codap-resources` layout | Tag → root only (overwrite in place) |
+| Trigger | GitHub Actions on tag push matching `v*` |
+| Versioning | Developer bumps `kSBVersion` *and* `package.json` `version` in a PR; tag matches; workflow validates all three agree |
+| CI scope | Build + Jest test on every push/PR; deploy job gated by tag |
+| Workflow file | Single `.github/workflows/ci.yml` (org convention) |
+| Sync mechanism | Plain `aws s3 sync --delete` (no `--size-only`) — correct in CI because build mtimes are always fresh |
+| CloudFront invalidation | Automatic, last step of deploy job |
+| Concurrency | `concurrency: { group: story-builder-deploy, cancel-in-progress: false }` on the deploy job to serialize tag races |
+| Generalization to other plugins | None for now — copy-paste when needed |
+
+## Workflow architecture
+
+A single GitHub Actions workflow at `.github/workflows/ci.yml` with two jobs.
+
+```yaml
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+
+jobs:
+  build_test:           # always runs
+  deploy:               # gated by tag; needs build_test
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build_test
+    concurrency:
+      group: story-builder-deploy
+      cancel-in-progress: false
+```
+
+`build_test` runs on every push to `master`, every PR, and every tag push. It primes the artifact that `deploy` consumes — `deploy` does not rebuild, so deployed bits are byte-identical to what passed tests.
+
+The `branches: [master]` filter on push avoids double-running CI when a feature-branch push opens a PR (the PR event covers branch CI).
+
+## Release flow
+
+The repo's PR convention drives the version-bump cadence:
+
+1. Open a version-bump PR that updates both:
+   - `src/models/story_builder.ts` → `kSBVersion = '0.87'`
+   - `package.json` → `"version": "0.87"`
+2. Review and merge to `master`.
+3. Tag the merge commit: `git tag v0.87 && git push --tags`.
+
+Tag format is `v<semver>` (e.g., `v0.87`), matching the workflow's `'v*'` tag filter and the `v` prefix convention common in the org.
+
+The workflow validates and never writes back to the repo. Forgetting to bump shows up as a failed CI run — recoverable by a small follow-up PR, then a fresh tag.
+
+The above is the steady-state flow. **For the first release**, the package.json version makes a single jump from its long-stale `0.1.0` straight to the new version (e.g., `0.87`) as part of the bump PR — there is no intermediate alignment to `0.86`. This is deliberate: the mismatched state on master (immediately after the workflow-introducing PR merges, but before the first bump PR) is exactly the state that lets Stage 1 of commissioning prove the validation step works. See **Testing / commissioning strategy** below.
+
+## Workflow step-by-step
+
+### `build_test` job
+
+```yaml
+runs-on: ubuntu-latest
+steps:
+  - uses: actions/checkout@v4
+  - uses: actions/setup-node@v4
+    with:
+      node-version: '18'
+      cache: 'npm'
+  - run: npm ci
+  - run: CI=true npm test -- --watchAll=false
+    env: { NODE_OPTIONS: --openssl-legacy-provider }
+  - run: npm run build
+    env: { NODE_OPTIONS: --openssl-legacy-provider }
+  - uses: actions/upload-artifact@v4
+    with:
+      name: build
+      path: build/
+```
+
+Notes:
+- `--openssl-legacy-provider` is required because react-scripts 4.0.3 / webpack 4 use OpenSSL APIs removed in Node 17+. Same flag the V2 codap CI uses.
+- `CI=true` plus `--watchAll=false` makes `react-scripts test` exit instead of starting watch mode.
+- Single Node version (18). No matrix — overkill for this repo.
+- `actions/setup-node@v4`'s `cache: 'npm'` keys on `package-lock.json` and avoids re-downloading dependencies on every run.
+
+### `deploy` job
+
+```yaml
+needs: build_test
+if: startsWith(github.ref, 'refs/tags/v')
+runs-on: ubuntu-latest
+concurrency:
+  group: story-builder-deploy
+  cancel-in-progress: false
+env:
+  AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION:    us-east-1
+  TAG:                   ${{ github.ref_name }}      # e.g., "v0.87"
+steps:
+  - uses: actions/checkout@v4                        # need source for validation step
+  - uses: actions/download-artifact@v4
+    with: { name: build, path: build }
+
+  - name: Validate tag matches kSBVersion and package.json
+    run: |
+      TAG_VERSION="${TAG#v}"
+      SB_VERSION=$(sed -nE "s/.*kSBVersion = \"([^\"]+)\".*/\1/p" src/models/story_builder.ts)
+      PKG_VERSION=$(node -p "require('./package.json').version")
+      if [[ "$TAG_VERSION" != "$SB_VERSION" || "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+        echo "Version mismatch: tag=$TAG_VERSION kSBVersion=$SB_VERSION package.json=$PKG_VERSION"
+        exit 1
+      fi
+
+  - name: Sync to codap-resources (v3 read path)
+    run: |
+      aws s3 sync build/ s3://codap-resources/plugins/story-builder/ \
+        --acl public-read --delete
+
+  - name: Sync to models-resources root (canonical)
+    run: |
+      aws s3 sync build/ s3://models-resources/story-builder/ \
+        --acl public-read --delete \
+        --exclude "version/*"
+
+  - name: Archive to models-resources/version/<tag>/
+    run: |
+      aws s3 sync build/ s3://models-resources/story-builder/version/${TAG}/ \
+        --acl public-read
+
+  - name: Invalidate CloudFront (codap-resources)
+    run: |
+      aws cloudfront create-invalidation \
+        --distribution-id E1RS9TZVZBEEEC \
+        --paths "/plugins/story-builder/*"
+
+  - name: Invalidate CloudFront (models-resources)
+    run: |
+      aws cloudfront create-invalidation \
+        --distribution-id <MODELS_RESOURCES_DIST_ID> \
+        --paths "/story-builder/*"
+```
+
+Flag rationale:
+- **No `--size-only` anywhere.** In CI, build artifacts always have fresh mtimes (newer than any prior S3 LastModified), so plain `aws s3 sync` uploads everything that has changed by mtime — which, in CI, is effectively the whole build. Cost: a few MB of bandwidth per release. Benefit: avoids the documented bug where `--size-only` misses content changes that happen to preserve file size (e.g., `index.html` with a swapped hashed-asset reference).
+- **`--delete`** on the two "live" sync targets so removed or renamed bundle files don't linger.
+- **`--exclude "version/*"`** on the models-resources root sync so the version archive isn't wiped. (No `--exclude "branch/*"` — we don't deploy branches.)
+- **Version-archive sync omits `--delete`** because it's a write to a fresh path.
+- **`--acl public-read`** matches the existing bucket convention; assumes ACLs remain enabled on both buckets (see Prerequisites).
+
+Step order: sync codap-resources, sync models-resources root, write version archive, invalidate codap-resources CloudFront, invalidate models-resources CloudFront. CloudFront invalidations run last so a partial failure earlier in the deploy leaves the old (cached) build serving until the run is recovered.
+
+## Error handling
+
+### Pre-write failures (cheap to recover; no deploy side effects)
+
+| Failure | Where | Recovery |
+|---|---|---|
+| `npm ci` fails | `build_test` | Fix lockfile/dependency, re-push tag or re-run from UI |
+| Jest tests fail | `build_test` | Fix tests or code; new PR; re-tag |
+| `npm run build` fails | `build_test` | Fix; re-tag |
+| Tag mismatch with `kSBVersion` / `package.json` | `deploy` validation step | Open a fix-up PR aligning the versions, merge, delete and re-push the tag (or push a new one) |
+
+The validation step runs before any AWS call, so a mismatch fails loud with zero deploy side effects.
+
+### Partial-deploy failures
+
+The three S3 sync steps run sequentially. If a later step fails, earlier writes have already happened, but CloudFront invalidation is the *last* step — so users keep seeing the cached old build until the run is recovered. Not a broken state, just an incomplete one.
+
+Recovery: re-run the failed job from the Actions UI. The artifact from `build_test` is preserved, so the re-run uses byte-identical bits. All sync and invalidation operations are idempotent. No new commit, no new tag.
+
+### CloudFront invalidation failures
+
+If S3 writes succeed but invalidation fails, users keep seeing the old build until invalidation succeeds. Two recovery paths:
+
+1. Re-run the invalidation step from the Actions UI.
+2. Invalidate manually via the `/codap-resources` skill or `aws cloudfront create-invalidation` directly.
+
+Invalidation is idempotent — running it twice is fine, just costs a second request.
+
+### Tag-race protection
+
+The `concurrency: { group: story-builder-deploy }` block serializes deploy runs. If two tags land in quick succession, the second waits for the first to finish before starting. Build jobs still run in parallel — only the deploy is serialized. Without this, two parallel deploys could race at the S3 layer and leave the older tag's artifact serving from root.
+
+### Explicitly not handled
+
+- **Re-tagging the same version** (force-pushing `v0.87` to a different commit): workflow re-runs and re-deploys. Loses audit trail; accepted trade-off for simplicity. Tag-protection rules are out of scope.
+- **Inline retries within a single sync step**: AWS CLI already retries individual operations. Re-running the job is the right escape hatch.
+
+## Testing / commissioning strategy
+
+The workflow is the deliverable; "testing" means commissioning safely. The repo's own state gives us two natural test cases — no test tags needed.
+
+### What `build_test` already covers
+
+Every push to a feature branch and every PR runs the build/test job, exercising:
+- `npm ci` correctness.
+- The existing Jest smoke test (`src/story_builder.test.tsx` — asserts the component renders without crashing).
+- `npm run build` produces an artifact (catches TS / webpack failures).
+
+So as soon as the PR that introduces `ci.yml` opens, the CI half is iteratively exercised without any AWS involvement.
+
+### Stage 1 — natural-state failure proves the validation step
+
+After the introducing PR merges, master is in a known mismatched state: `kSBVersion = '0.86'` and `package.json` version = `'0.1.0'`. Push `v0.86` as a tag at master HEAD. The deploy job runs; validation compares `tag → 0.86` against `kSBVersion → 0.86` (match) and `package.json → 0.1.0` (**mismatch**), and exits non-zero before any AWS call. We see the expected failure and confirm the validator does its job. No S3 writes, no tag namespace pollution beyond the `v0.86` tag itself (a legitimate marker for the current production code).
+
+### Stage 2 — version-bump PR proves end-to-end success
+
+Open a small follow-up PR that aligns both versions to `0.87` (also includes the CODAP-1362 fix already on master from PR #2). Merge. Tag `v0.87` at the new HEAD. The full deploy job runs:
+
+- Validation passes (`tag → 0.87`, `kSBVersion → 0.87`, `package.json → 0.87` all match).
+- All three S3 syncs and both CloudFront invalidations execute against production.
+- Verify by `aws s3 ls` against each prefix, by checking the two CloudFront distributions' recent invalidations, and by loading the new build in a CODAP V3 instance and confirming the CODAP-1362 fix is live.
+
+Stage 2 is also the real first ship of the bugfix, so commissioning and shipping are one act. If anything in Stage 2 fails (AWS creds, IAM, CloudFront perms), the fix is to address that underlying issue and re-run the workflow from the Actions UI.
+
+### Not tested in this design
+
+- Workflow YAML syntax beyond what GitHub validates on push (`actionlint` is overkill for ~80 lines of workflow).
+- CloudFront propagation latency (operational expectation; ~1 minute after invalidation).
+- Cross-version regressions on the V2 side (manual functional check during commissioning).
+
+## Prerequisites
+
+### Verify before the first deploy (blocking)
+
+1. **AWS GitHub secrets accessible to `concord-consortium/story-builder`.** Org-level `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` exist and are inherited. (Org-level is the assumption based on other repos; if they turn out to be repo-level elsewhere, provision them here.)
+2. **IAM policy for the role those creds back.** Must grant:
+   - `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` on `codap-resources/plugins/story-builder/*`
+   - Same three on `models-resources/story-builder/*`
+   - `cloudfront:CreateInvalidation` on the codap-resources distribution (`E1RS9TZVZBEEEC`)
+   - `cloudfront:CreateInvalidation` on the models-resources distribution (ID TBD)
+3. **Bucket ACL configuration.** Both buckets must permit `--acl public-read` writes. Newer S3 buckets default to "ACLs disabled" (bucket-owner-enforced ownership), which makes `--acl public-read` fail at PUT time. If either bucket has ACLs disabled, either re-enable them or switch to bucket-policy-based public access and drop `--acl public-read` from the workflow.
+4. **GitHub Actions enabled** on the story-builder repo (default for org repos; verify the setting is on).
+
+### Values still to look up
+
+1. **CloudFront distribution ID for `models-resources`.** Workflow has a `<MODELS_RESOURCES_DIST_ID>` placeholder; resolve via `aws cloudfront list-distributions` or by asking the org's AWS maintainer.
+2. **CloudFront serving URL for `models-resources/story-builder/`.** Not blocking for this design (we keep `codap-resources` as the V3 read path), but useful for any eventual V3-side migration.
+
+## Future work (explicitly out of this design)
+
+1. **Branch deploys + S3 lifecycle TTL.** Recipe is settled — drop `--size-only` (already done here), add a bucket lifecycle rule on `*/branch/*` with an N-day expiration so unmaintained branch dirs age out automatically. Add when a real preview-build need arises.
+2. **Extend pattern to other standard plugins** (codap-transformers, noaa-codap-plugin already have similar workflows; importer/sampler/scrambler in `codap-data-interactives` are still bundled via the V2 build). When a third plugin needs the same dual-bucket pattern, that's a natural moment to extract a reusable workflow.
+3. **Decide fate of `bin/deploy_v7` and `bin/deploy_v8`.** Out of scope here; revisit when the legacy V2 endpoints they target stop serving traffic.
+4. **Pick one bucket as canonical; drop the other.** The dual-bucket setup is transitional. At some point we evaluate trade-offs (org convention vs. existing V3 read path vs. whatever pattern emerges) and pick one. Whichever isn't chosen gets dropped from this workflow, and any consumers of the dropped location are updated.
+5. **Make `package.json` the version source of truth.** Refactor `src/models/story_builder.ts` to import the version from `package.json` so validation only checks one place. Deferred.
+6. **Drop `--openssl-legacy-provider`.** Disappears whenever story-builder modernizes its build toolchain.
+
+## Coordination with existing skills
+
+- **`/codap-v2-build`** continues to bundle story-builder via `makeExtn` for V2 releases — no change. The new workflow is an *additional* deploy path for V3, not a replacement.
+- **`/codap-resources`** continues to be the right tool for one-off manual syncs (emergency hotfixes outside CI, or syncing other plugins still on the manual path). Once V3 migrates off `codap-resources/plugins/story-builder/` (Future-work item 4), the skill's "Syncing from V2 Build" section becomes story-builder-irrelevant but stays useful for other plugins.

--- a/src/models/story_area.ts
+++ b/src/models/story_area.ts
@@ -173,7 +173,6 @@ export class StoryArea {
 
 	toggleIsAutoSave() {
 		this.isAutoSave = !this.isAutoSave;
-		let tSrcMoment = this.momentsManager.srcMoment
 	}
 
 	getSetIsAutoSave(iSetting?: boolean) {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`: build + Jest test on every push to master and every PR; deploys to S3 on `v[0-9]*` tag push with per-file `Cache-Control` headers (no CloudFront invalidation needed).
- Adds the design spec at `docs/superpowers/specs/2026-05-26-story-builder-build-and-deploy-design.md` and the implementation plan at `docs/superpowers/plans/2026-05-26-story-builder-build-and-deploy.md` covering rationale, decisions, prerequisites, and commissioning plan.
- Dual-bucket publish during the V2→V3 transition: `codap-resources/plugins/story-builder/` (current V3 read path) and `models-resources/story-builder/` (org standard) — the latter also writes a per-tag archive to `models-resources/story-builder/version/v<x.y>/`.

## Cache strategy
Per scytacki's review feedback: hashed assets (`build/static/*`) and immutable archive paths get `public, max-age=31536000, immutable`; HTML and root manifests get `no-cache, no-store, must-revalidate`. Both CloudFront distributions use cache policy `S3-CORS-1` (MinTTL=1) so origin Cache-Control is respected at the edge and in browsers. No `aws cloudfront create-invalidation` step (and no `cloudfront:CreateInvalidation` in the IAM policy).

## Prerequisites still needed before the first deploy

AWS authentication uses **GitHub OIDC** (no long-lived secrets — per org convention, see [starter-projects/doc/deploy-setup.md](https://github.com/concord-consortium/starter-projects/blob/master/doc/deploy-setup.md)). An IAM admin needs to:

1. Run `concord-consortium/starter-projects/scripts/create-deploy-role.sh story-builder` to create the `story-builder` IAM role with the trust policy scoped to this repo and the shared `S3-deploy-by-role-tag` managed policy attached (covers `models-resources/story-builder/*`).
2. Attach a supplemental inline policy granting `s3:PutObject` / `s3:DeleteObject` on `codap-resources/plugins/story-builder/*` and `s3:ListBucket` on `codap-resources` (scoped to the story-builder prefix). The exact policy JSON is in `docs/superpowers/plans/...` Task 1 Step 4.

`build_test` runs without any AWS involvement, so this PR can merge before the role is set up — the `deploy` job simply won't fire until a `v[0-9]*` tag is pushed.

## Test plan
- [ ] Verify `Build & Test` runs green on this PR.
- [ ] After merge **and after the OIDC role is provisioned**, push `v0.86` tag at master HEAD. Confirm the deploy job's **validation step fails** (master has `kSBVersion = '0.86'` but `package.json` version is still `'0.1.0'`), with no S3 writes — this is the natural-state failure described in spec §Testing → Stage 1.
- [ ] Open the follow-up version-bump PR (CODAP-1366-release-0.87, planned separately) that aligns `kSBVersion` and `package.json` to `0.87`. Tag `v0.87`. Confirm full deploy succeeds end-to-end. Verify `Cache-Control` on a sample of objects via `aws s3api head-object`. Confirm the CODAP-1362 fix is live in V3.

Refs CODAP-1366.
