### PR TITLE
CODAP-1366: release version 0.87

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "story-builder",
-  "version": "0.1.0",
+  "version": "0.87",
   "homepage": ".",
   "type": "module",
   "dependencies": {

--- a/src/models/story_builder.ts
+++ b/src/models/story_builder.ts
@@ -3,7 +3,7 @@ import {initializePlugin} from "../lib/codap-helper";
 import codapInterface from "../lib/CodapInterface";
 import tr from "../utilities/translate"
 
-export const kSBVersion = "0.86";
+export const kSBVersion = "0.87";
 export class StoryBuilder {
 
 	public storyArea:StoryArea;


### PR DESCRIPTION
## Summary
- Bumps `kSBVersion` from `0.86` to `0.87` and aligns `package.json` `version` (long-stale at `0.1.0`) to `0.87`.
- First release through the new `ci.yml` deploy workflow (introduced in CODAP-1366 / PR #3).
- First release that includes the CODAP-1362 fix (PR #2, merged `49acc8b`).

## Stage 1 result (recorded for context)
The new workflow's validation step was exercised on master with annotated tag `v0.86` (commit `98626e7`). Run [26914278494](https://github.com/concord-consortium/story-builder/actions/runs/26914278494) failed at validation with `tag=0.86 kSBVersion=0.86 package.json=0.1.0` and refused to deploy — exactly the expected behavior given the pre-bump mismatch. No S3 writes occurred.

## Test plan
- [ ] `Build & Test` passes on this PR.
- [ ] After merge, tag `v0.87` at the new master HEAD (annotated). Confirm the deploy job validates successfully, archives to `s3://models-resources/story-builder/version/v0.87/`, and syncs to both canonical targets with correct `Cache-Control` headers (`no-cache, no-store, must-revalidate` for HTML/manifests; `public, max-age=31536000, immutable` for hashed assets).
- [ ] Confirm CODAP V3 picks up the new build: the CODAP-1362 fix is verifiable by adding Story Builder to a new V3 document and then a graph — the first moment dirties (turns yellow).

Refs CODAP-1366.
